### PR TITLE
Roadmap #38: workspace bootstrap retry UX + telemetry

### DIFF
--- a/src/app/api/workspaces/bootstrap/route.ts
+++ b/src/app/api/workspaces/bootstrap/route.ts
@@ -9,7 +9,26 @@ import { workspaceInvites, workspaceMembers, workspaces } from '@/lib/db/schema'
 import { isWorkspacesV1Enabled } from '@/lib/flags';
 import { emitLaunchMetric } from '@/lib/observability/launch-metrics';
 
-export async function POST() {
+function parseBootstrapAttempt(request: Request): number {
+  const rawAttempt = request.headers.get('x-workspace-bootstrap-attempt');
+  const parsed = Number.parseInt(rawAttempt ?? '', 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return 1;
+  }
+  return parsed;
+}
+
+function retryOutcome(attempt: number, status: 'success' | 'error'): 'not_needed' | 'recovered' | 'initial_failed' | 'retry_failed' {
+  if (status === 'success') {
+    return attempt > 1 ? 'recovered' : 'not_needed';
+  }
+
+  return attempt > 1 ? 'retry_failed' : 'initial_failed';
+}
+
+export async function POST(request: Request) {
+  const attempt = parseBootstrapAttempt(request);
+
   try {
     if (!isWorkspacesV1Enabled()) {
       emitLaunchMetric({
@@ -17,6 +36,11 @@ export async function POST() {
         status: 'error',
         source: 'api',
         errorCode: 'feature_disabled',
+        metadata: {
+          errorClass: 'feature_gate',
+          attempt,
+          retryOutcome: retryOutcome(attempt, 'error'),
+        },
       });
       return NextResponse.json({ error: 'Not found' }, { status: 404 });
     }
@@ -28,6 +52,11 @@ export async function POST() {
         status: 'error',
         source: 'api',
         errorCode: 'auth_required',
+        metadata: {
+          errorClass: 'auth',
+          attempt,
+          retryOutcome: retryOutcome(attempt, 'error'),
+        },
       });
       return actorResult.response;
     }
@@ -88,6 +117,8 @@ export async function POST() {
         userId: actorResult.actor.user.id,
         memberships: memberships.length,
         invites: invites.length,
+        attempt,
+        retryOutcome: retryOutcome(attempt, 'success'),
       },
     });
 
@@ -102,7 +133,12 @@ export async function POST() {
       status: 'error',
       source: 'api',
       errorCode: 'bootstrap_exception',
-      metadata: { message: error instanceof Error ? error.message : String(error) },
+      metadata: {
+        errorClass: 'exception',
+        attempt,
+        retryOutcome: retryOutcome(attempt, 'error'),
+        message: error instanceof Error ? error.message : String(error),
+      },
     });
 
     return NextResponse.json(

--- a/src/components/dashboard/DashboardPage.tsx
+++ b/src/components/dashboard/DashboardPage.tsx
@@ -18,6 +18,8 @@ export function DashboardPage() {
     isLoadingList,
     retryLoadCanvases,
     loadError,
+    loadErrorTitle,
+    retryActionLabel,
     filteredCanvases,
     personalCanvases,
     teamCanvases,
@@ -62,6 +64,7 @@ export function DashboardPage() {
                   canvases={personalCanvases}
                   isLoading={isLoadingList}
                   loadError={loadError}
+                  loadErrorTitle={loadErrorTitle}
                   searchQuery={searchQuery}
                   onCreateCanvas={handleCreateCanvas}
                   onRename={handleRename}
@@ -69,6 +72,7 @@ export function DashboardPage() {
                   onDelete={handleDelete}
                   onRefreshPreview={handleRefreshPreview}
                   onRetryLoad={retryLoadCanvases}
+                  retryLabel={retryActionLabel}
                   onBrowseTemplates={() => setActiveTab('templates')}
                 />
               </div>

--- a/src/components/dashboard/ProjectsGrid.tsx
+++ b/src/components/dashboard/ProjectsGrid.tsx
@@ -9,6 +9,7 @@ interface ProjectsGridProps {
   canvases: CanvasMetadata[];
   isLoading: boolean;
   loadError?: string | null;
+  loadErrorTitle?: string;
   searchQuery: string;
   onCreateCanvas: () => void;
   onRename: (id: string, name: string) => void;
@@ -16,6 +17,7 @@ interface ProjectsGridProps {
   onDelete: (id: string) => void;
   onRefreshPreview?: (id: string) => void;
   onRetryLoad?: () => void;
+  retryLabel?: string;
   onBrowseTemplates?: () => void;
 }
 
@@ -39,6 +41,7 @@ export function ProjectsGrid({
   canvases,
   isLoading,
   loadError,
+  loadErrorTitle,
   searchQuery,
   onCreateCanvas,
   onRename,
@@ -46,6 +49,7 @@ export function ProjectsGrid({
   onDelete,
   onRefreshPreview,
   onRetryLoad,
+  retryLabel,
   onBrowseTemplates,
 }: ProjectsGridProps) {
   if (isLoading) {
@@ -56,13 +60,13 @@ export function ProjectsGrid({
     return (
       <div className="rounded-xl border border-border bg-card/50 px-6 py-12 text-center">
         <AlertCircle className="mx-auto mb-3 h-7 w-7 text-amber-400" />
-        <p className="text-base font-medium text-foreground">Couldn’t load your projects</p>
+        <p className="text-base font-medium text-foreground">{loadErrorTitle || 'Couldn’t load your projects'}</p>
         <p className="mx-auto mt-2 max-w-xl text-sm text-muted-foreground">{loadError}</p>
         <button
           onClick={onRetryLoad}
           className="mt-5 rounded-lg bg-[#3b82f6] px-4 py-2 text-white transition-colors hover:bg-[#2563eb]"
         >
-          Retry loading projects
+          {retryLabel || 'Retry loading projects'}
         </button>
       </div>
     );

--- a/src/components/dashboard/hooks/useDashboardState.ts
+++ b/src/components/dashboard/hooks/useDashboardState.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { toast } from 'sonner';
 import { useAppStore } from '@/stores/app-store';
@@ -12,6 +12,8 @@ export type TemplateFilter = 'all';
 
 const validTabs: TabType[] = ['my-spaces', 'shared', 'templates'];
 
+type DashboardLoadFailureStage = 'bootstrap' | 'canvases' | null;
+
 export interface DashboardState {
   // State
   isCreating: boolean;
@@ -19,6 +21,8 @@ export interface DashboardState {
   searchQuery: string;
   isLoadingList: boolean;
   loadError: string | null;
+  loadErrorTitle: string;
+  retryActionLabel: string;
   filteredCanvases: ReturnType<typeof useAppStore.getState>['canvasList'];
   personalCanvases: ReturnType<typeof useAppStore.getState>['canvasList'];
   teamCanvases: ReturnType<typeof useAppStore.getState>['canvasList'];
@@ -46,6 +50,9 @@ export function useDashboardState(): DashboardState {
   const [isCreating, setIsCreating] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [loadErrorTitle, setLoadErrorTitle] = useState('Couldn’t load your projects');
+  const [loadFailureStage, setLoadFailureStage] = useState<DashboardLoadFailureStage>(null);
+  const bootstrapAttemptRef = useRef(0);
 
   // Read tab from URL params
   const tabParam = searchParams.get('tab');
@@ -95,19 +102,81 @@ export function useDashboardState(): DashboardState {
   const teamCanvases = filteredCanvases.filter((canvas) => canvas.workspaceType === 'team' && !canvas.isShared);
   const sharedCanvases = filteredCanvases.filter((canvas) => canvas.isShared);
 
-  const retryLoadCanvases = useCallback(async () => {
-    try {
-      setLoadError(null);
-      await loadCanvasList();
-    } catch (error) {
-      setLoadError(error instanceof Error ? error.message : 'Unknown error');
-    }
-  }, [loadCanvasList]);
+  const clearLoadError = useCallback(() => {
+    setLoadError(null);
+    setLoadErrorTitle('Couldn’t load your projects');
+    setLoadFailureStage(null);
+  }, []);
 
-  useEffect(() => {
-    async function init() {
-      try {
-        setLoadError(null);
+  const loadCanvasesWithHandling = useCallback(async () => {
+    try {
+      await loadCanvasList();
+      clearLoadError();
+      return true;
+    } catch (error) {
+      setLoadFailureStage('canvases');
+      setLoadErrorTitle('Couldn’t load your projects');
+      setLoadError(error instanceof Error ? error.message : 'Unknown error');
+      return false;
+    }
+  }, [clearLoadError, loadCanvasList]);
+
+  const runWorkspaceBootstrap = useCallback(async () => {
+    bootstrapAttemptRef.current += 1;
+
+    const response = await fetch('/api/workspaces/bootstrap', {
+      method: 'POST',
+      headers: {
+        'x-workspace-bootstrap-attempt': String(bootstrapAttemptRef.current),
+      },
+    });
+
+    let payload: unknown = null;
+    try {
+      payload = await response.json();
+    } catch {
+      // no-op, fallback message is used below
+    }
+
+    if (!response.ok) {
+      let errorMessage = 'Failed to initialize workspace.';
+      if (
+        payload &&
+        typeof payload === 'object' &&
+        'error' in payload &&
+        typeof payload.error === 'string' &&
+        payload.error.trim()
+      ) {
+        errorMessage = payload.error;
+      }
+
+      setLoadFailureStage('bootstrap');
+      setLoadErrorTitle('Workspace setup failed');
+      setLoadError(errorMessage);
+      toast.error(`Workspace setup failed: ${errorMessage}`);
+      return false;
+    }
+
+    if (payload && typeof payload === 'object') {
+      const bootstrap = payload as {
+        invites?: Array<{ id: string; status: string; email: string; role: string }>;
+        memberships?: Array<{ workspaceId: string; workspaceName: string; workspaceType: string; role: string }>;
+      };
+      setInvites(bootstrap.invites || []);
+      setMemberships(bootstrap.memberships || []);
+    } else {
+      setInvites([]);
+      setMemberships([]);
+    }
+
+    return true;
+  }, []);
+
+  const initializeDashboard = useCallback(async (options?: { runSetup?: boolean }) => {
+    clearLoadError();
+
+    try {
+      if (options?.runSetup !== false) {
         // Initialize sync with SQLite (if configured)
         await initializeSync();
 
@@ -116,36 +185,38 @@ export function useDashboardState(): DashboardState {
         if (migratedId) {
           toast.success('Migrated your existing canvas');
         }
-
-        const bootstrapResponse = await fetch('/api/workspaces/bootstrap', { method: 'POST' });
-        if (!bootstrapResponse.ok) {
-          let errorMessage = 'Failed to initialize workspace.';
-
-          try {
-            const body = await bootstrapResponse.json();
-            if (typeof body?.error === 'string' && body.error.trim()) {
-              errorMessage = body.error;
-            }
-          } catch {
-            // no-op: fallback message is already set
-          }
-
-          setLoadError(errorMessage);
-          toast.error(`Workspace setup failed: ${errorMessage}`);
-          return;
-        }
-
-        const bootstrap = await bootstrapResponse.json();
-        setInvites(bootstrap.invites || []);
-        setMemberships(bootstrap.memberships || []);
-
-        await loadCanvasList();
-      } catch (error) {
-        setLoadError(error instanceof Error ? error.message : 'Unknown error');
       }
+
+      const bootstrapped = await runWorkspaceBootstrap();
+      if (!bootstrapped) {
+        return;
+      }
+
+      await loadCanvasesWithHandling();
+    } catch (error) {
+      setLoadFailureStage('canvases');
+      setLoadErrorTitle('Couldn’t load your projects');
+      setLoadError(error instanceof Error ? error.message : 'Unknown error');
     }
-    init();
-  }, [loadCanvasList, migrateLegacyData, initializeSync]);
+  }, [clearLoadError, initializeSync, loadCanvasesWithHandling, migrateLegacyData, runWorkspaceBootstrap]);
+
+  const retryLoadCanvases = useCallback(async () => {
+    if (loadFailureStage === 'bootstrap') {
+      await initializeDashboard({ runSetup: false });
+      return;
+    }
+
+    clearLoadError();
+    await loadCanvasesWithHandling();
+  }, [clearLoadError, initializeDashboard, loadCanvasesWithHandling, loadFailureStage]);
+
+  useEffect(() => {
+    initializeDashboard();
+  }, [initializeDashboard]);
+
+  const retryActionLabel = loadFailureStage === 'bootstrap'
+    ? 'Retry workspace setup'
+    : 'Retry loading projects';
 
   const handleCreateCanvas = useCallback(async () => {
     setIsCreating(true);
@@ -229,6 +300,8 @@ export function useDashboardState(): DashboardState {
     searchQuery,
     isLoadingList,
     loadError,
+    loadErrorTitle,
+    retryActionLabel,
     filteredCanvases,
     personalCanvases,
     teamCanvases,


### PR DESCRIPTION
## Summary
Implements roadmap issue #38 (workspace bootstrap retry UX + telemetry hardening).

### Included
- Explicit bootstrap failure UX state (`Workspace setup failed`)
- Contextual retry CTA (`Retry workspace setup`)
- Retry now re-runs workspace bootstrap flow (not only canvas reload)
- Silent continuation on bootstrap failure removed
- Bootstrap telemetry enriched (`errorClass`, `attempt`, `retryOutcome`)

## Validation
- `npm run build` passes

## Related
- Closes #38
