### PR TITLE
feat(prompt-studio): creative director plugin for prompt generation

### DIFF
--- a/src/app/api/plugins/prompt-studio/stream/route.ts
+++ b/src/app/api/plugins/prompt-studio/stream/route.ts
@@ -1,0 +1,289 @@
+/**
+ * Prompt Studio Streaming API Route
+ *
+ * Simple Mastra agent stream — no sandbox, no plan gate.
+ * Receives chat messages, streams creative prompt generation as SSE.
+ */
+
+import { NextResponse } from 'next/server';
+import { promptStudioAgent } from '@/mastra/agents/prompt-studio-agent';
+import { RequestContext } from '@mastra/core/di';
+import { emitLaunchMetric } from '@/lib/observability/launch-metrics';
+import { evaluatePluginLaunchById, emitPluginPolicyAuditEvent } from '@/lib/plugins/launch-policy';
+import { z } from 'zod';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 120;
+
+const PromptStudioRequestSchema = z.object({
+  prompt: z.string().min(1).max(4000).optional(),
+  messages: z.array(z.object({
+    role: z.enum(['user', 'assistant']),
+    content: z.string().min(1).max(4000),
+  })).max(50).optional(),
+  context: z.object({
+    nodeId: z.string().max(128).optional(),
+    phase: z.string().max(64).optional(),
+  }).optional(),
+}).superRefine((value, ctx) => {
+  if ((!value.prompt || value.prompt.trim().length === 0) && (!value.messages || value.messages.length === 0)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Either prompt or messages is required',
+      path: ['prompt'],
+    });
+  }
+});
+
+export async function POST(request: Request) {
+  try {
+    const policyDecision = evaluatePluginLaunchById('prompt-studio');
+    emitPluginPolicyAuditEvent({
+      source: 'api',
+      decision: policyDecision,
+      metadata: { method: 'POST', path: '/api/plugins/prompt-studio/stream' },
+    });
+
+    if (!policyDecision.allowed) {
+      emitLaunchMetric({
+        metric: 'plugin_execution',
+        status: 'error',
+        source: 'api',
+        pluginId: 'prompt-studio',
+        errorCode: policyDecision.code,
+      });
+
+      return NextResponse.json(
+        {
+          error: 'Plugin launch blocked by policy.',
+          code: policyDecision.code,
+          reason: policyDecision.reason,
+        },
+        { status: policyDecision.code === 'PLUGIN_NOT_FOUND' ? 404 : 403 }
+      );
+    }
+
+    const rawBody = await request.json();
+    const parsedBody = PromptStudioRequestSchema.safeParse(rawBody);
+    if (!parsedBody.success) {
+      return NextResponse.json(
+        {
+          error: 'Invalid request payload',
+          issues: parsedBody.error.issues,
+        },
+        { status: 400 }
+      );
+    }
+
+    const { prompt, messages, context } = parsedBody.data;
+
+    let agentMessages: Array<{ role: 'user' | 'assistant' | 'system'; content: string }>;
+
+    if (messages && messages.length > 0) {
+      agentMessages = [...messages];
+    } else if (prompt) {
+      agentMessages = [{ role: 'user', content: prompt }];
+    } else {
+      emitLaunchMetric({
+        metric: 'plugin_execution',
+        status: 'error',
+        source: 'api',
+        pluginId: 'prompt-studio',
+        errorCode: 'missing_prompt_or_messages',
+      });
+      return NextResponse.json(
+        { error: 'Either prompt or messages is required' },
+        { status: 400 }
+      );
+    }
+
+    const requestContext = new RequestContext();
+    if (context?.nodeId) {
+      requestContext.set('nodeId' as never, context.nodeId as never);
+    }
+
+    console.log(`[Prompt Studio API] Starting stream: nodeId=${context?.nodeId}, messageCount=${agentMessages.length}`);
+
+    const result = await promptStudioAgent.stream(
+      agentMessages as Parameters<typeof promptStudioAgent.stream>[0],
+      {
+        maxSteps: 20,
+        requestContext,
+      }
+    );
+
+    const encoder = new TextEncoder();
+    let closed = false;
+
+    const readable = new ReadableStream({
+      async start(controller) {
+        const safeEnqueue = (data: Uint8Array) => {
+          if (!closed) {
+            try { controller.enqueue(data); } catch { closed = true; }
+          }
+        };
+        const safeClose = () => {
+          if (!closed) {
+            closed = true;
+            try { controller.close(); } catch { /* already closed */ }
+          }
+        };
+
+        request.signal.addEventListener('abort', () => {
+          closed = true;
+          safeClose();
+        });
+
+        try {
+          const reader = result.fullStream.getReader();
+
+          while (!closed) {
+            const { done, value: chunk } = await reader.read();
+            if (done || closed) break;
+
+            let sseData: string | null = null;
+
+            switch (chunk.type) {
+              case 'text-delta':
+                sseData = JSON.stringify({
+                  type: 'text-delta',
+                  text: chunk.payload.text,
+                });
+                break;
+
+              case 'tool-call':
+                sseData = JSON.stringify({
+                  type: 'tool-call',
+                  toolCallId: chunk.payload.toolCallId,
+                  toolName: chunk.payload.toolName,
+                  args: chunk.payload.args,
+                });
+                break;
+
+              case 'tool-result':
+                sseData = JSON.stringify({
+                  type: 'tool-result',
+                  toolCallId: chunk.payload.toolCallId,
+                  toolName: chunk.payload.toolName,
+                  result: chunk.payload.result,
+                  isError: chunk.payload.isError,
+                });
+                break;
+
+              case 'tool-error':
+                sseData = JSON.stringify({
+                  type: 'tool-result',
+                  toolCallId: chunk.payload.toolCallId,
+                  toolName: chunk.payload.toolName,
+                  result: { error: chunk.payload.error instanceof Error ? chunk.payload.error.message : String(chunk.payload.error) },
+                  isError: true,
+                });
+                break;
+
+              case 'step-finish':
+                sseData = JSON.stringify({
+                  type: 'step-finish',
+                  usage: chunk.payload.output?.usage ?? chunk.payload.totalUsage,
+                });
+                break;
+
+              case 'finish':
+                sseData = JSON.stringify({
+                  type: 'finish',
+                  finishReason: chunk.payload.stepResult?.reason,
+                });
+                break;
+
+              case 'error':
+                sseData = JSON.stringify({
+                  type: 'error',
+                  error: chunk.payload.error instanceof Error
+                    ? chunk.payload.error.message
+                    : String(chunk.payload.error),
+                });
+                break;
+
+              case 'reasoning-delta':
+                if (chunk.payload.text) {
+                  sseData = JSON.stringify({
+                    type: 'reasoning-delta',
+                    text: chunk.payload.text,
+                  });
+                }
+                break;
+
+              case 'reasoning-start':
+              case 'reasoning-end':
+              case 'reasoning-signature':
+              case 'redacted-reasoning':
+                break;
+
+              default:
+                break;
+            }
+
+            if (sseData && !closed) {
+              safeEnqueue(encoder.encode(`data: ${sseData}\n\n`));
+            }
+          }
+
+          if (!closed) {
+            const text = await result.text;
+            const usage = await result.usage;
+            emitLaunchMetric({
+              metric: 'plugin_execution',
+              status: 'success',
+              source: 'api',
+              pluginId: 'prompt-studio',
+            });
+            safeEnqueue(encoder.encode(`data: ${JSON.stringify({
+              type: 'complete',
+              text,
+              usage,
+            })}\n\n`));
+          }
+
+          safeClose();
+        } catch (error) {
+          console.error('[Prompt Studio API] Stream error:', error);
+          emitLaunchMetric({
+            metric: 'plugin_execution',
+            status: 'error',
+            source: 'api',
+            pluginId: 'prompt-studio',
+            errorCode: 'stream_error',
+            metadata: { message: error instanceof Error ? error.message : String(error) },
+          });
+          if (!closed) {
+            const errMsg = error instanceof Error ? error.message : String(error);
+            safeEnqueue(encoder.encode(`data: ${JSON.stringify({ type: 'error', error: errMsg })}\n\n`));
+          }
+          safeClose();
+        }
+      },
+    });
+
+    return new Response(readable, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'Connection': 'keep-alive',
+      },
+    });
+  } catch (error) {
+    console.error('[Prompt Studio API] Error:', error);
+    emitLaunchMetric({
+      metric: 'plugin_execution',
+      status: 'error',
+      source: 'api',
+      pluginId: 'prompt-studio',
+      errorCode: 'execution_failed',
+      metadata: { message: error instanceof Error ? error.message : String(error) },
+    });
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/canvas/ContextMenu.tsx
+++ b/src/components/canvas/ContextMenu.tsx
@@ -36,6 +36,7 @@ import '@/lib/plugins/official/product-shot';
 import '@/lib/plugins/official/agents/animation-generator';
 import '@/lib/plugins/official/agents/motion-analyzer';
 import '@/lib/plugins/official/agents/svg-studio';
+import '@/lib/plugins/official/agents/prompt-studio';
 
 interface MenuItem {
   id: string;

--- a/src/components/canvas/NodeToolbar.tsx
+++ b/src/components/canvas/NodeToolbar.tsx
@@ -50,6 +50,7 @@ import '@/lib/plugins/official/product-shot';
 import '@/lib/plugins/official/agents/animation-generator';
 import '@/lib/plugins/official/agents/motion-analyzer';
 import '@/lib/plugins/official/agents/svg-studio';
+import '@/lib/plugins/official/agents/prompt-studio';
 import {
   Tooltip,
   TooltipContent,

--- a/src/components/canvas/nodes/PluginNode.tsx
+++ b/src/components/canvas/nodes/PluginNode.tsx
@@ -17,12 +17,14 @@ import { pluginRegistry } from '@/lib/plugins/registry';
 import { AnimationNode } from '@/lib/plugins/official/agents/animation-generator';
 import { MotionAnalyzerNode } from '@/lib/plugins/official/agents/motion-analyzer';
 import { SvgStudioNode } from '@/lib/plugins/official/agents/svg-studio';
+import { PromptStudioNode } from '@/lib/plugins/official/agents/prompt-studio';
 
 // Component registry - maps pluginId to component
 const PLUGIN_COMPONENTS: Record<string, React.ComponentType<NodeProps<Node<PluginNodeData, 'pluginNode'>>>> = {
   'animation-generator': AnimationNode as unknown as React.ComponentType<NodeProps<Node<PluginNodeData, 'pluginNode'>>>,
   'motion-analyzer': MotionAnalyzerNode as unknown as React.ComponentType<NodeProps<Node<PluginNodeData, 'pluginNode'>>>,
   'svg-studio': SvgStudioNode as unknown as React.ComponentType<NodeProps<Node<PluginNodeData, 'pluginNode'>>>,
+  'prompt-studio': PromptStudioNode as unknown as React.ComponentType<NodeProps<Node<PluginNodeData, 'pluginNode'>>>,
 
 };
 

--- a/src/lib/plugins/official/agents/prompt-studio/PromptStudioNode.tsx
+++ b/src/lib/plugins/official/agents/prompt-studio/PromptStudioNode.tsx
@@ -1,0 +1,725 @@
+'use client';
+
+/**
+ * PromptStudioNode Component
+ *
+ * Creative director chat — generates production-quality prompts
+ * for image/video models. Text output handle connects to generators.
+ * Matches AnimationNode / MotionAnalyzerNode UI patterns.
+ */
+
+import { memo, useState, useRef, useCallback, useEffect } from 'react';
+import type { NodeProps, Node } from '@xyflow/react';
+import { Handle, Position } from '@xyflow/react';
+import type { PluginNodeData } from '@/lib/types';
+import { useCanvasStore } from '@/stores/canvas-store';
+import {
+  Sparkles,
+  ArrowUp,
+  Copy,
+  Check,
+  Loader2,
+  RotateCcw,
+  Terminal,
+  Square,
+  ChevronDown,
+  Camera,
+  Palette,
+  Zap,
+} from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type {
+  PromptStudioNodeState,
+  PromptStudioMessage,
+  ToolCallItem,
+  ThinkingBlockItem,
+  GeneratedPrompt,
+} from './types';
+import { TOOL_DISPLAY_NAMES } from './events';
+import { usePromptStudioStream } from './hooks';
+
+// ─── Constants ──────────────────────────────────────────────────────────
+function createDefaultState(nodeId: string): PromptStudioNodeState {
+  return {
+    nodeId,
+    phase: 'idle',
+    messages: [],
+    toolCalls: [],
+    thinkingBlocks: [],
+    generatedPrompts: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+const UI_TOOLS = new Set(['set_thinking']);
+
+// ─── Markdown components (matches AnimationNode) ────────────────────────
+const mdComponents = {
+  p: ({ children }: { children?: React.ReactNode }) => (
+    <p className="text-xs leading-[1.5] text-[var(--an-text-muted)] mb-1.5 last:mb-0">{children}</p>
+  ),
+  strong: ({ children }: { children?: React.ReactNode }) => (
+    <strong className="font-semibold text-[var(--an-text-secondary)]">{children}</strong>
+  ),
+  em: ({ children }: { children?: React.ReactNode }) => (
+    <em className="italic text-[var(--an-text-muted)]">{children}</em>
+  ),
+  ul: ({ children }: { children?: React.ReactNode }) => (
+    <ul className="list-disc list-inside space-y-0.5 text-xs text-[var(--an-text-muted)] mb-1.5 last:mb-0">{children}</ul>
+  ),
+  ol: ({ children }: { children?: React.ReactNode }) => (
+    <ol className="list-decimal list-inside space-y-0.5 text-xs text-[var(--an-text-muted)] mb-1.5 last:mb-0">{children}</ol>
+  ),
+  li: ({ children }: { children?: React.ReactNode }) => (
+    <li className="text-xs leading-[1.5] text-[var(--an-text-muted)]">{children}</li>
+  ),
+  code: ({ children, className }: { children?: React.ReactNode; className?: string }) => {
+    const isBlock = className?.includes('language-');
+    if (isBlock) {
+      return (
+        <pre className="bg-[var(--an-bg-elevated)] rounded-md px-2.5 py-2 my-1.5 overflow-x-auto">
+          <code className="text-[10px] leading-[1.4] text-[var(--an-accent-text)] font-mono">{children}</code>
+        </pre>
+      );
+    }
+    return (
+      <code className="bg-[var(--an-bg-card)] text-[var(--an-accent-text)] text-[11px] px-1 py-0.5 rounded font-mono">{children}</code>
+    );
+  },
+  pre: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  h1: ({ children }: { children?: React.ReactNode }) => (
+    <h1 className="text-sm font-bold text-[var(--an-text-primary)] mb-1.5">{children}</h1>
+  ),
+  h2: ({ children }: { children?: React.ReactNode }) => (
+    <h2 className="text-xs font-bold text-[var(--an-text-primary)] mb-1">{children}</h2>
+  ),
+  h3: ({ children }: { children?: React.ReactNode }) => (
+    <h3 className="text-xs font-semibold text-[var(--an-text-secondary)] mb-1">{children}</h3>
+  ),
+};
+
+// ─── Sequence counter ────────────────────────────────────────────────────
+let globalSeq = 0;
+function nextSeq(): number { return ++globalSeq; }
+
+// ─── Prompt Card Component ──────────────────────────────────────────────
+function PromptCard({
+  prompt,
+  isLatest,
+}: {
+  prompt: GeneratedPrompt;
+  isLatest: boolean;
+}) {
+  const [copied, setCopied] = useState(false);
+  const [expanded, setExpanded] = useState(isLatest);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      let fullText = prompt.prompt;
+      if (prompt.negativePrompt) {
+        fullText += `\n\nNegative: ${prompt.negativePrompt}`;
+      }
+      if (prompt.parameters) {
+        const params = Object.entries(prompt.parameters).map(([k, v]) => `${k} ${v}`).join(' ');
+        fullText += `\n\n${params}`;
+      }
+      await navigator.clipboard.writeText(fullText);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch { /* clipboard fail */ }
+  }, [prompt]);
+
+  // Model badge color
+  const modelColor = getModelColor(prompt.targetModel);
+
+  return (
+    <div className={`
+      rounded-lg border transition-all duration-200
+      ${isLatest
+        ? 'border-amber-500/40 bg-amber-500/5 shadow-[0_0_12px_-4px_rgba(245,158,11,0.15)]'
+        : 'border-[var(--an-border)] bg-[var(--an-bg-card)]'
+      }
+    `}>
+      {/* Header */}
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center gap-2 px-3 py-2 text-left"
+      >
+        <div className={`w-5 h-5 rounded flex items-center justify-center ${modelColor.bg}`}>
+          <Camera className={`w-3 h-3 ${modelColor.text}`} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <span className="text-[11px] font-medium text-[var(--an-text-primary)] truncate block">
+            {prompt.label || 'Generated Prompt'}
+          </span>
+          <span className={`text-[10px] ${modelColor.text}`}>
+            {prompt.targetModel}
+          </span>
+        </div>
+        <button
+          onClick={(e) => { e.stopPropagation(); handleCopy(); }}
+          className="p-1 rounded hover:bg-white/5 transition-colors"
+          title="Copy prompt"
+        >
+          {copied ? (
+            <Check className="w-3 h-3 text-green-400" />
+          ) : (
+            <Copy className="w-3 h-3 text-[var(--an-text-muted)]" />
+          )}
+        </button>
+        <ChevronDown className={`w-3 h-3 text-[var(--an-text-muted)] transition-transform ${expanded ? 'rotate-180' : ''}`} />
+      </button>
+
+      {/* Content */}
+      {expanded && (
+        <div className="px-3 pb-3 space-y-2">
+          <div className="bg-[var(--an-bg-elevated)] rounded-md p-2.5">
+            <p className="text-[11px] leading-[1.6] text-[var(--an-text-secondary)] whitespace-pre-wrap select-text">
+              {prompt.prompt}
+            </p>
+          </div>
+          {prompt.negativePrompt && (
+            <div className="bg-red-500/5 border border-red-500/20 rounded-md p-2">
+              <p className="text-[10px] font-medium text-red-400 mb-0.5">Negative</p>
+              <p className="text-[10px] leading-[1.5] text-red-300/70 select-text">
+                {prompt.negativePrompt}
+              </p>
+            </div>
+          )}
+          {prompt.parameters && Object.keys(prompt.parameters).length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {Object.entries(prompt.parameters).map(([key, value]) => (
+                <span
+                  key={key}
+                  className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-[var(--an-bg-elevated)] text-[10px] text-[var(--an-text-muted)] font-mono"
+                >
+                  {key} {value}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function getModelColor(model: string): { bg: string; text: string } {
+  const m = model.toLowerCase();
+  if (m.includes('midjourney')) return { bg: 'bg-blue-500/15', text: 'text-blue-400' };
+  if (m.includes('dall') || m.includes('openai')) return { bg: 'bg-green-500/15', text: 'text-green-400' };
+  if (m.includes('stable') || m.includes('sdxl') || m.includes('sd3')) return { bg: 'bg-purple-500/15', text: 'text-purple-400' };
+  if (m.includes('flux')) return { bg: 'bg-cyan-500/15', text: 'text-cyan-400' };
+  if (m.includes('imagen')) return { bg: 'bg-red-500/15', text: 'text-red-400' };
+  if (m.includes('nano') || m.includes('banana')) return { bg: 'bg-yellow-500/15', text: 'text-yellow-400' };
+  if (m.includes('kling') || m.includes('runway') || m.includes('sora') || m.includes('luma')) return { bg: 'bg-pink-500/15', text: 'text-pink-400' };
+  if (m.includes('ideogram')) return { bg: 'bg-orange-500/15', text: 'text-orange-400' };
+  if (m.includes('leonardo')) return { bg: 'bg-emerald-500/15', text: 'text-emerald-400' };
+  return { bg: 'bg-amber-500/15', text: 'text-amber-400' };
+}
+
+// ─── Main Component ─────────────────────────────────────────────────────
+
+type PromptStudioNodeType = Node<PluginNodeData, 'pluginNode'>;
+
+function PromptStudioNodeComponent({ id, data, selected }: NodeProps<PromptStudioNodeType>) {
+  const updateNodeData = useCanvasStore((s) => s.updateNodeData);
+
+  // ── Local state (UI-only, not persisted) ──
+  const [ls, setLs] = useState<PromptStudioNodeState>(() => {
+    const persisted = data.state as unknown as PromptStudioNodeState | undefined;
+    if (persisted?.nodeId) return persisted;
+    return createDefaultState(id);
+  });
+
+  const [inputValue, setInputValue] = useState('');
+  const [thinkingMsg, setThinkingMsg] = useState('');
+  const [reasoning, setReasoning] = useState('');
+  const [showReasoning, setShowReasoning] = useState(false);
+
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const latestStateRef = useRef(ls);
+  latestStateRef.current = ls;
+
+  // ── Streaming hook ──
+  const { isStreaming, stream, abort } = usePromptStudioStream();
+
+  // ── Persist state ──
+  const persistState = useCallback((state: PromptStudioNodeState) => {
+    updateNodeData(id, { state });
+  }, [id, updateNodeData]);
+
+  // ── Auto-scroll ──
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [ls.messages, ls.toolCalls, ls.thinkingBlocks, ls.generatedPrompts]);
+
+  // ── Build timeline ──
+  type TimelineItem =
+    | { kind: 'message'; data: PromptStudioMessage; seq: number }
+    | { kind: 'toolCall'; data: ToolCallItem; seq: number }
+    | { kind: 'thinking'; data: ThinkingBlockItem; seq: number }
+    | { kind: 'prompt'; data: GeneratedPrompt; seq: number };
+
+  const timeline: TimelineItem[] = [];
+  ls.messages.forEach((m) => timeline.push({ kind: 'message', data: m, seq: m.seq ?? 0 }));
+  ls.toolCalls.filter(tc => !UI_TOOLS.has(tc.toolName)).forEach((tc) => timeline.push({ kind: 'toolCall', data: tc, seq: tc.seq ?? 0 }));
+  ls.thinkingBlocks.forEach((tb) => timeline.push({ kind: 'thinking', data: tb, seq: tb.seq ?? 0 }));
+  ls.generatedPrompts.forEach((p, i) => {
+    const seq = ls.toolCalls.find(tc => tc.toolName === 'generate_prompt' && tc.output?.includes(p.id))?.seq ?? (i + 1000);
+    timeline.push({ kind: 'prompt', data: p, seq: typeof seq === 'number' ? seq : 0 });
+  });
+  timeline.sort((a, b) => a.seq - b.seq);
+
+  // ── Handle send message ──
+  const handleSendMessage = useCallback(async () => {
+    const text = inputValue.trim();
+    if (!text || isStreaming) return;
+
+    setInputValue('');
+
+    const userMsg: PromptStudioMessage = {
+      id: `msg_${Date.now()}`,
+      role: 'user',
+      content: text,
+      timestamp: new Date().toISOString(),
+      seq: nextSeq(),
+    };
+
+    const updatedState: PromptStudioNodeState = {
+      ...latestStateRef.current,
+      phase: 'generating',
+      messages: [...latestStateRef.current.messages, userMsg],
+      updatedAt: new Date().toISOString(),
+    };
+    setLs(updatedState);
+    persistState(updatedState);
+
+    setThinkingMsg('');
+    setReasoning('');
+
+    // Build message history for the agent
+    const agentMessages = updatedState.messages.map(m => ({
+      role: m.role as 'user' | 'assistant',
+      content: m.content,
+    }));
+
+    let streamingAssistantText = '';
+    const toolCallArgs = new Map<string, Record<string, unknown>>();
+
+    await stream(agentMessages, { nodeId: id, phase: 'generating' }, {
+      onTextDelta: (delta) => {
+        streamingAssistantText += delta;
+        setLs(prev => ({ ...prev, streamingText: streamingAssistantText }));
+      },
+      onReasoningDelta: (delta) => {
+        setReasoning(prev => prev + delta);
+      },
+      onToolCall: (event) => {
+        toolCallArgs.set(event.toolCallId, event.args);
+
+        if (event.toolName === 'set_thinking') {
+          setThinkingMsg(event.args.message as string || '');
+          return;
+        }
+
+        const tcItem: ToolCallItem = {
+          id: `tc_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+          toolCallId: event.toolCallId,
+          toolName: event.toolName,
+          displayName: TOOL_DISPLAY_NAMES[event.toolName] || event.toolName,
+          status: 'running',
+          args: event.args,
+          timestamp: new Date().toISOString(),
+          seq: nextSeq(),
+        };
+
+        setLs(prev => ({
+          ...prev,
+          toolCalls: [...prev.toolCalls, tcItem],
+        }));
+      },
+      onToolResult: (event) => {
+        if (event.toolName === 'set_thinking') return;
+
+        // Mark tool call as done
+        setLs(prev => ({
+          ...prev,
+          toolCalls: prev.toolCalls.map(tc =>
+            tc.toolCallId === event.toolCallId
+              ? { ...tc, status: (event.isError ? 'failed' : 'done') as 'done' | 'failed' }
+              : tc
+          ),
+        }));
+
+        // Handle generate_prompt result
+        if (event.toolName === 'generate_prompt' && !event.isError) {
+          const args = toolCallArgs.get(event.toolCallId) || {};
+          const newPrompt: GeneratedPrompt = {
+            id: (event.result.promptId as string) || `prompt_${Date.now()}`,
+            prompt: (args.prompt as string) || '',
+            targetModel: (args.targetModel as string) || 'General',
+            label: args.label as string | undefined,
+            negativePrompt: args.negativePrompt as string | undefined,
+            parameters: args.parameters as Record<string, string> | undefined,
+            createdAt: new Date().toISOString(),
+          };
+
+          setLs(prev => ({
+            ...prev,
+            generatedPrompts: [...prev.generatedPrompts, newPrompt],
+          }));
+        }
+      },
+      onComplete: (fullText) => {
+        setThinkingMsg('');
+
+        // Strip HTML tags from response
+        const cleanText = fullText.replace(/<[^>]*>/g, '').trim();
+
+        setLs(prev => {
+          const assistantMsg: PromptStudioMessage | null = cleanText ? {
+            id: `msg_${Date.now()}_asst`,
+            role: 'assistant',
+            content: cleanText,
+            timestamp: new Date().toISOString(),
+            seq: nextSeq(),
+          } : null;
+
+          const newState: PromptStudioNodeState = {
+            ...prev,
+            phase: 'chatting',
+            messages: assistantMsg ? [...prev.messages, assistantMsg] : prev.messages,
+            streamingText: undefined,
+            reasoning: undefined,
+            updatedAt: new Date().toISOString(),
+          };
+          persistState(newState);
+          return newState;
+        });
+      },
+      onError: (error) => {
+        setThinkingMsg('');
+        setLs(prev => {
+          const newState: PromptStudioNodeState = {
+            ...prev,
+            phase: 'error',
+            error: { message: error, canRetry: true },
+            streamingText: undefined,
+            updatedAt: new Date().toISOString(),
+          };
+          persistState(newState);
+          return newState;
+        });
+      },
+    });
+  }, [inputValue, isStreaming, id, stream, persistState]);
+
+  // ── Handle reset ──
+  const handleReset = useCallback(() => {
+    abort();
+    const newState = createDefaultState(id);
+    setLs(newState);
+    persistState(newState);
+    setThinkingMsg('');
+    setReasoning('');
+    setInputValue('');
+  }, [id, abort, persistState]);
+
+  // ── Handle key down ──
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSendMessage();
+    }
+  }, [handleSendMessage]);
+
+  // ── Status config ──
+  const headerConfig = {
+    idle: { label: 'Ready', color: 'text-[var(--an-text-muted)]', dot: 'bg-zinc-500' },
+    generating: { label: 'Creating', color: 'text-amber-400', dot: 'bg-amber-400 animate-pulse' },
+    chatting: { label: 'Active', color: 'text-emerald-400', dot: 'bg-emerald-400' },
+    complete: { label: 'Complete', color: 'text-emerald-400', dot: 'bg-emerald-400' },
+    error: { label: 'Error', color: 'text-red-400', dot: 'bg-red-400' },
+  };
+  const status = headerConfig[ls.phase] || headerConfig.idle;
+
+  // ── Live status for screen readers ──
+  const liveStatus = isStreaming ? (thinkingMsg || 'Generating...') : '';
+
+  // ── Latest prompt for output handle data ──
+  const latestPrompt = ls.generatedPrompts[ls.generatedPrompts.length - 1];
+
+  return (
+    <div className="group/node" data-prompt-studio-node>
+    <div
+      className={`
+        w-[420px] rounded-2xl overflow-hidden shadow-xl transition-all duration-200
+        bg-[var(--an-bg)] border-2
+        ${selected
+          ? 'border-amber-500/60 shadow-[0_0_24px_-4px_rgba(245,158,11,0.2)]'
+          : 'border-[var(--an-border)] hover:border-[var(--an-border-hover)]'
+        }
+      `}
+      style={{
+        // CSS variables (matching animation node palette, but with amber accent)
+        '--an-bg': '#0c0c0f',
+        '--an-bg-card': '#141418',
+        '--an-bg-elevated': '#1a1a20',
+        '--an-border': '#27272a',
+        '--an-border-hover': '#3f3f46',
+        '--an-text-primary': '#fafafa',
+        '--an-text-secondary': '#d4d4d8',
+        '--an-text-muted': '#a1a1aa',
+        '--an-accent': '#f59e0b',
+        '--an-accent-hover': '#d97706',
+        '--an-accent-text': '#fbbf24',
+      } as React.CSSProperties}
+    >
+      {/* ── Input Handle (left) ── */}
+      <Handle
+        type="target"
+        position={Position.Left}
+        id="text"
+        className="!w-3 !h-3 !bg-blue-500 !border-2 !border-[var(--an-bg)]"
+        style={{ top: 24 }}
+      />
+
+      {/* ── Header ── */}
+      <div className="px-4 py-2.5 flex items-center gap-3 border-b border-[var(--an-border)]">
+        <div className="h-8 w-8 rounded-lg bg-amber-500/10 flex items-center justify-center">
+          <Sparkles className="w-4 h-4 text-amber-400" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="text-[13px] font-semibold text-[var(--an-text-primary)] leading-tight">
+            Prompt Studio
+          </h3>
+          <div className="flex items-center gap-1.5">
+            <div className={`w-1.5 h-1.5 rounded-full ${status.dot}`} />
+            <span className={`text-[10px] ${status.color}`}>
+              {isStreaming ? (thinkingMsg || 'Generating...') : status.label}
+            </span>
+          </div>
+        </div>
+        <div className="flex items-center gap-1">
+          {(ls.messages.length > 0 || ls.generatedPrompts.length > 0) && (
+            <button
+              onClick={handleReset}
+              className="p-1.5 rounded-md hover:bg-white/5 transition-colors"
+              title="Reset"
+            >
+              <RotateCcw className="w-3.5 h-3.5 text-[var(--an-text-muted)]" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* ── Timeline / Messages ── */}
+      <div
+        className="overflow-y-auto"
+        style={{ maxHeight: 400, minHeight: ls.phase === 'idle' && timeline.length === 0 ? 0 : 120 }}
+      >
+        <div className="p-3 space-y-2.5">
+          {/* Empty state */}
+          {ls.phase === 'idle' && timeline.length === 0 && (
+            <div className="py-6 flex flex-col items-center gap-3 text-center">
+              <div className="w-10 h-10 rounded-xl bg-amber-500/10 flex items-center justify-center">
+                <Palette className="w-5 h-5 text-amber-400" />
+              </div>
+              <div>
+                <p className="text-[11px] text-[var(--an-text-secondary)] font-medium">Creative Director</p>
+                <p className="text-[10px] text-[var(--an-text-muted)] mt-0.5 max-w-[260px]">
+                  Describe what you want to create and I'll craft the perfect prompt for any image or video model.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-1.5 justify-center mt-1">
+                {[
+                  'Cinematic product shot',
+                  'Editorial portrait',
+                  'Architectural render',
+                  'Abstract art',
+                ].map(suggestion => (
+                  <button
+                    key={suggestion}
+                    onClick={() => { setInputValue(suggestion); inputRef.current?.focus(); }}
+                    className="px-2 py-1 rounded-full bg-[var(--an-bg-elevated)] text-[10px] text-[var(--an-text-muted)] hover:text-[var(--an-text-secondary)] hover:bg-white/5 transition-colors"
+                  >
+                    {suggestion}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Timeline items */}
+          {timeline.map((item) => {
+            switch (item.kind) {
+              case 'message': {
+                const msg = item.data;
+                const isUser = msg.role === 'user';
+                return (
+                  <div
+                    key={msg.id}
+                    className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}
+                  >
+                    <div
+                      className={`
+                        max-w-[85%] rounded-xl px-3 py-2
+                        ${isUser
+                          ? 'bg-amber-500/15 border border-amber-500/20'
+                          : 'bg-[var(--an-bg-card)] border border-[var(--an-border)]'
+                        }
+                      `}
+                    >
+                      {isUser ? (
+                        <p className="text-xs text-[var(--an-text-secondary)] whitespace-pre-wrap">{msg.content}</p>
+                      ) : (
+                        <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>
+                          {msg.content}
+                        </ReactMarkdown>
+                      )}
+                    </div>
+                  </div>
+                );
+              }
+
+              case 'toolCall': {
+                const tc = item.data;
+                return (
+                  <div key={tc.id} className="flex items-center gap-2 px-2 py-1">
+                    <div className={`w-4 h-4 rounded flex items-center justify-center ${
+                      tc.status === 'running' ? 'bg-amber-500/15' :
+                      tc.status === 'done' ? 'bg-emerald-500/15' : 'bg-red-500/15'
+                    }`}>
+                      {tc.status === 'running' ? (
+                        <Loader2 className="w-2.5 h-2.5 text-amber-400 animate-spin" />
+                      ) : tc.status === 'done' ? (
+                        <Check className="w-2.5 h-2.5 text-emerald-400" />
+                      ) : (
+                        <Zap className="w-2.5 h-2.5 text-red-400" />
+                      )}
+                    </div>
+                    <span className="text-[10px] text-[var(--an-text-muted)]">{tc.displayName}</span>
+                  </div>
+                );
+              }
+
+              case 'thinking': {
+                const tb = item.data;
+                return (
+                  <div key={tb.id} className="flex items-center gap-2 px-2 py-1">
+                    <Terminal className="w-3 h-3 text-[var(--an-text-muted)]" />
+                    <span className="text-[10px] text-[var(--an-text-muted)] italic">{tb.label}</span>
+                  </div>
+                );
+              }
+
+              case 'prompt': {
+                const p = item.data;
+                const isLatest = p.id === latestPrompt?.id;
+                return (
+                  <PromptCard key={p.id} prompt={p} isLatest={isLatest} />
+                );
+              }
+            }
+          })}
+
+          {/* Streaming text */}
+          {ls.streamingText && (
+            <div className="flex justify-start">
+              <div className="max-w-[85%] rounded-xl px-3 py-2 bg-[var(--an-bg-card)] border border-[var(--an-border)]">
+                <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>
+                  {ls.streamingText}
+                </ReactMarkdown>
+              </div>
+            </div>
+          )}
+
+          {/* Reasoning toggle */}
+          {reasoning && (
+            <button
+              onClick={() => setShowReasoning(!showReasoning)}
+              className="flex items-center gap-1.5 px-2 py-1 text-[10px] text-[var(--an-text-muted)] hover:text-[var(--an-text-secondary)] transition-colors"
+            >
+              <Terminal className="w-3 h-3" />
+              {showReasoning ? 'Hide reasoning' : 'Show reasoning'}
+              <ChevronDown className={`w-3 h-3 transition-transform ${showReasoning ? 'rotate-180' : ''}`} />
+            </button>
+          )}
+          {showReasoning && reasoning && (
+            <div className="bg-[var(--an-bg-elevated)] border border-[var(--an-border)] rounded-lg px-3 py-2">
+              <p className="text-[10px] leading-[1.5] text-[var(--an-text-muted)] italic whitespace-pre-wrap">{reasoning}</p>
+            </div>
+          )}
+
+          <div ref={messagesEndRef} />
+        </div>
+      </div>
+
+      {/* ── Chat Input ── */}
+      <div className="border-t border-[var(--an-border)] p-3">
+        <div className="flex items-end gap-2">
+          <div className="flex-1 relative">
+            <textarea
+              ref={inputRef}
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={ls.phase === 'idle' ? 'Describe your vision...' : 'Refine the prompt...'}
+              className="
+                w-full bg-[var(--an-bg-card)] border border-[var(--an-border)]
+                rounded-xl px-3 py-2 text-xs text-[var(--an-text-secondary)]
+                placeholder:text-[var(--an-text-muted)]/50
+                focus:outline-none focus:border-amber-500/40
+                resize-none overflow-hidden
+                nowheel nodrag
+              "
+              rows={1}
+              style={{ minHeight: 36, maxHeight: 120 }}
+              onInput={(e) => {
+                const target = e.target as HTMLTextAreaElement;
+                target.style.height = 'auto';
+                target.style.height = Math.min(target.scrollHeight, 120) + 'px';
+              }}
+            />
+          </div>
+          <button
+            onClick={isStreaming ? abort : handleSendMessage}
+            disabled={!isStreaming && !inputValue.trim()}
+            className={`
+              h-9 w-9 rounded-xl flex items-center justify-center transition-all
+              ${isStreaming
+                ? 'bg-red-500/20 hover:bg-red-500/30 border border-red-500/30'
+                : inputValue.trim()
+                  ? 'bg-amber-500 hover:bg-amber-600'
+                  : 'bg-[var(--an-bg-elevated)] border border-[var(--an-border)] opacity-40'
+              }
+            `}
+          >
+            {isStreaming ? (
+              <Square className="w-3.5 h-3.5 text-red-400" />
+            ) : (
+              <ArrowUp className="w-3.5 h-3.5 text-white" />
+            )}
+          </button>
+        </div>
+        <div className="sr-only" aria-live="polite">{liveStatus}</div>
+      </div>
+    </div>
+
+    {/* ── Output Handle (right) ── */}
+    <Handle
+      type="source"
+      position={Position.Right}
+      id="prompt-output"
+      className="!w-3 !h-3 !bg-amber-500 !border-2 !border-[var(--an-bg)]"
+      style={{ top: '50%' }}
+    />
+    </div>
+  );
+}
+
+export const PromptStudioNode = memo(PromptStudioNodeComponent);

--- a/src/lib/plugins/official/agents/prompt-studio/events.ts
+++ b/src/lib/plugins/official/agents/prompt-studio/events.ts
@@ -1,0 +1,150 @@
+/**
+ * Prompt Studio Stream Event Types
+ *
+ * Shared types for SSE events between the stream API route
+ * and the usePromptStudioStream hook.
+ */
+
+// ============================================
+// RAW SSE EVENT TYPES (from Mastra stream)
+// ============================================
+
+export interface TextDeltaEvent {
+  type: 'text-delta';
+  text: string;
+}
+
+export interface ToolCallEvent {
+  type: 'tool-call';
+  toolCallId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+}
+
+export interface ToolResultEvent {
+  type: 'tool-result';
+  toolCallId: string;
+  toolName: string;
+  result: Record<string, unknown>;
+  isError?: boolean;
+}
+
+export interface StepFinishEvent {
+  type: 'step-finish';
+  usage?: { promptTokens: number; completionTokens: number; totalTokens: number };
+}
+
+export interface FinishEvent {
+  type: 'finish';
+  finishReason?: string;
+}
+
+export interface CompleteEvent {
+  type: 'complete';
+  text: string;
+  usage?: { promptTokens: number; completionTokens: number; totalTokens: number };
+  finishReason?: string;
+}
+
+export interface ErrorEvent {
+  type: 'error';
+  error: string;
+}
+
+export interface ReasoningDeltaEvent {
+  type: 'reasoning-delta';
+  text: string;
+}
+
+/** Union of all SSE event types */
+export type PromptStudioStreamEvent =
+  | TextDeltaEvent
+  | ToolCallEvent
+  | ToolResultEvent
+  | StepFinishEvent
+  | FinishEvent
+  | CompleteEvent
+  | ErrorEvent
+  | ReasoningDeltaEvent;
+
+// ============================================
+// APPLICATION-LEVEL EVENT TYPES
+// ============================================
+
+export interface ThinkingAppEvent {
+  kind: 'thinking';
+  message: string;
+}
+
+export interface PromptGeneratedAppEvent {
+  kind: 'prompt_generated';
+  promptId: string;
+  prompt: string;
+  targetModel: string;
+  label?: string;
+  negativePrompt?: string;
+  parameters?: Record<string, string>;
+}
+
+export type PromptStudioAppEvent =
+  | ThinkingAppEvent
+  | PromptGeneratedAppEvent;
+
+// ============================================
+// TOOL NAME CONSTANTS
+// ============================================
+
+export const UI_TOOL_NAMES = [
+  'set_thinking',
+] as const;
+
+export const PROMPT_TOOL_NAMES = [
+  'generate_prompt',
+] as const;
+
+export type UIToolName = typeof UI_TOOL_NAMES[number];
+export type PromptToolName = typeof PROMPT_TOOL_NAMES[number];
+export type PromptStudioToolName = UIToolName | PromptToolName;
+
+/** Tool display names for the UI */
+export const TOOL_DISPLAY_NAMES: Record<string, string> = {
+  set_thinking: 'Thinking',
+  generate_prompt: 'Crafting Prompt',
+};
+
+/**
+ * Map a tool-call event to an application-level event.
+ */
+export function toolCallToAppEvent(toolName: string, args: Record<string, unknown>): PromptStudioAppEvent | null {
+  switch (toolName) {
+    case 'set_thinking':
+      return {
+        kind: 'thinking',
+        message: args.message as string,
+      };
+    default:
+      return null;
+  }
+}
+
+/**
+ * Map a tool-result event to an application-level event.
+ */
+export function toolResultToAppEvent(toolName: string, args: Record<string, unknown>, result: Record<string, unknown>): PromptStudioAppEvent | null {
+  if (result.success === false) return null;
+
+  switch (toolName) {
+    case 'generate_prompt':
+      return {
+        kind: 'prompt_generated',
+        promptId: result.promptId as string,
+        prompt: args.prompt as string,
+        targetModel: args.targetModel as string,
+        label: args.label as string | undefined,
+        negativePrompt: args.negativePrompt as string | undefined,
+        parameters: args.parameters as Record<string, string> | undefined,
+      };
+    default:
+      return null;
+  }
+}

--- a/src/lib/plugins/official/agents/prompt-studio/hooks/index.ts
+++ b/src/lib/plugins/official/agents/prompt-studio/hooks/index.ts
@@ -1,0 +1,1 @@
+export { usePromptStudioStream } from './usePromptStudioStream';

--- a/src/lib/plugins/official/agents/prompt-studio/hooks/usePromptStudioStream.ts
+++ b/src/lib/plugins/official/agents/prompt-studio/hooks/usePromptStudioStream.ts
@@ -1,0 +1,229 @@
+/**
+ * usePromptStudioStream Hook
+ *
+ * Consumes the prompt studio streaming API via SSE.
+ * Simple pattern — no sandbox events, no video handling.
+ */
+
+import { useState, useCallback, useRef } from 'react';
+import type { PromptStudioStreamEvent, PromptStudioAppEvent } from '../events';
+import { toolCallToAppEvent, toolResultToAppEvent } from '../events';
+
+// ============================================
+// Types
+// ============================================
+
+interface StreamContext {
+  nodeId?: string;
+  phase?: string;
+}
+
+interface ToolCallEvent {
+  toolCallId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+}
+
+interface ToolResultEvent {
+  toolCallId: string;
+  toolName: string;
+  result: Record<string, unknown>;
+  isError?: boolean;
+}
+
+export interface PromptStudioStreamCallbacks {
+  onTextDelta?: (text: string) => void;
+  onReasoningDelta?: (text: string) => void;
+  onToolCall?: (event: ToolCallEvent) => void;
+  onToolResult?: (event: ToolResultEvent) => void;
+  onComplete?: (text: string) => void;
+  onError?: (error: string) => void;
+  onAppEvent?: (event: PromptStudioAppEvent) => void;
+}
+
+export type StreamInput = string | Array<{ role: 'user' | 'assistant'; content: string }>;
+
+interface UsePromptStudioStreamReturn {
+  isStreaming: boolean;
+  streamedText: string;
+  error: string | null;
+  stream: (input: StreamInput, context?: StreamContext, callbacks?: PromptStudioStreamCallbacks) => Promise<string>;
+  abort: () => void;
+}
+
+// ============================================
+// Hook
+// ============================================
+
+// Track tool-call args so we can pair them with tool-result
+const pendingToolArgs = new Map<string, Record<string, unknown>>();
+
+export function usePromptStudioStream(): UsePromptStudioStreamReturn {
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [streamedText, setStreamedText] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const completeFiredRef = useRef(false);
+  const abortedRef = useRef(false);
+
+  const abort = useCallback(() => {
+    abortedRef.current = true;
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+      abortControllerRef.current = null;
+    }
+    setIsStreaming(false);
+  }, []);
+
+  const stream = useCallback(
+    async (input: StreamInput, context?: StreamContext, callbacks?: PromptStudioStreamCallbacks): Promise<string> => {
+      abort();
+      abortControllerRef.current = new AbortController();
+      abortedRef.current = false;
+      setIsStreaming(true);
+      setStreamedText('');
+      setError(null);
+      completeFiredRef.current = false;
+      pendingToolArgs.clear();
+
+      let fullText = '';
+
+      try {
+        const requestBody = typeof input === 'string'
+          ? { prompt: input, context }
+          : { messages: input, context };
+
+        const response = await fetch('/api/plugins/prompt-studio/stream', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(requestBody),
+          signal: abortControllerRef.current.signal,
+        });
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({ error: 'Stream request failed' }));
+          throw new Error(errorData.error || `Stream request failed (${response.status})`);
+        }
+
+        if (!response.body) throw new Error('No response body');
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const events = buffer.split('\n\n');
+          buffer = events.pop() || '';
+
+          for (const event of events) {
+            if (!event.trim()) continue;
+
+            const dataPayload = event
+              .split('\n')
+              .filter(line => line.startsWith('data: '))
+              .map(line => line.slice(6))
+              .join('');
+
+            if (!dataPayload) continue;
+
+            try {
+              const data: PromptStudioStreamEvent = JSON.parse(dataPayload);
+
+              switch (data.type) {
+                case 'text-delta':
+                  fullText += data.text;
+                  setStreamedText(fullText);
+                  callbacks?.onTextDelta?.(data.text);
+                  break;
+
+                case 'reasoning-delta':
+                  callbacks?.onReasoningDelta?.(data.text);
+                  break;
+
+                case 'tool-call': {
+                  // Store args for pairing with tool-result
+                  pendingToolArgs.set(data.toolCallId, data.args);
+                  callbacks?.onToolCall?.({
+                    toolCallId: data.toolCallId,
+                    toolName: data.toolName,
+                    args: data.args,
+                  });
+                  const appEvent = toolCallToAppEvent(data.toolName, data.args);
+                  if (appEvent) callbacks?.onAppEvent?.(appEvent);
+                  break;
+                }
+
+                case 'tool-result': {
+                  const args = pendingToolArgs.get(data.toolCallId) || {};
+                  pendingToolArgs.delete(data.toolCallId);
+                  callbacks?.onToolResult?.({
+                    toolCallId: data.toolCallId,
+                    toolName: data.toolName,
+                    result: data.result,
+                    isError: data.isError,
+                  });
+                  if (!data.isError) {
+                    const appEvent = toolResultToAppEvent(data.toolName, args, data.result);
+                    if (appEvent) callbacks?.onAppEvent?.(appEvent);
+                  }
+                  break;
+                }
+
+                case 'complete':
+                  fullText = data.text || fullText;
+                  setStreamedText(fullText);
+                  completeFiredRef.current = true;
+                  if (!abortedRef.current) {
+                    callbacks?.onComplete?.(fullText);
+                  }
+                  break;
+
+                case 'error':
+                  setError(data.error || 'Unknown stream error');
+                  callbacks?.onError?.(data.error || 'Unknown stream error');
+                  break;
+
+                default:
+                  break;
+              }
+            } catch (parseErr) {
+              console.warn('[usePromptStudioStream] Failed to parse SSE event:', dataPayload.slice(0, 200), parseErr);
+            }
+          }
+        }
+
+        if (!completeFiredRef.current && !abortedRef.current) {
+          completeFiredRef.current = true;
+          callbacks?.onComplete?.(fullText);
+        }
+
+        abortControllerRef.current = null;
+        setIsStreaming(false);
+        return fullText;
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') {
+          abortControllerRef.current = null;
+          setIsStreaming(false);
+          return fullText;
+        }
+        const errorMessage = err instanceof Error ? err.message : 'Stream failed';
+        if (abortedRef.current) {
+          setIsStreaming(false);
+          return fullText;
+        }
+        console.error('[usePromptStudioStream] Stream error:', errorMessage);
+        setError(errorMessage);
+        setIsStreaming(false);
+        callbacks?.onError?.(errorMessage);
+        return fullText;
+      }
+    },
+    [abort]
+  );
+
+  return { isStreaming, streamedText, error, stream, abort };
+}

--- a/src/lib/plugins/official/agents/prompt-studio/index.ts
+++ b/src/lib/plugins/official/agents/prompt-studio/index.ts
@@ -1,0 +1,80 @@
+/**
+ * Prompt Studio Plugin
+ *
+ * Creative director AI that generates production-quality prompts
+ * for image and video generation models. Thinks like a cinematographer —
+ * knows camera angles, lenses, lighting rigs, color science, composition.
+ *
+ * Architecture: Node-based Agent Plugin (renders directly on canvas)
+ * Output: Text prompts via output handle → connects to image/video generators
+ */
+
+import { Sparkles } from 'lucide-react';
+import { pluginRegistry } from '@/lib/plugins/registry';
+import type { AgentPlugin } from '@/lib/plugins/types';
+
+export const promptStudioPlugin: AgentPlugin = {
+  id: 'prompt-studio',
+  name: 'Prompt Studio',
+  description: 'Creative director AI that crafts production-quality prompts for image and video models',
+  icon: Sparkles,
+  category: 'planning',
+  type: 'agent',
+  version: '1.0.0',
+  author: {
+    type: 'official',
+    name: 'Koda Team',
+    verified: true,
+  },
+  visibility: 'public',
+  policy: {
+    capabilityDeclarations: ['canvas:read'],
+    distributionVisibility: ['oss', 'hosted'],
+    trustTier: 'official',
+  },
+
+  rendering: {
+    mode: 'node',
+    component: 'PromptStudioNode',
+    defaultSize: { width: 420, height: 'auto' },
+    resizable: true,
+    collapsible: true,
+  },
+
+  capabilities: [
+    'canvas:read',
+  ],
+
+  services: [
+    'ai',
+  ],
+
+  phases: [
+    { id: 'idle', label: 'Ready', initial: true },
+    { id: 'generating', label: 'Creating', showProgress: true },
+    { id: 'chatting', label: 'Active' },
+    { id: 'complete', label: 'Complete', terminal: true },
+    { id: 'error', label: 'Error', terminal: true },
+  ],
+
+  handles: {
+    inputs: [
+      { id: 'text', name: 'Brief', type: 'text', optional: true },
+    ],
+    outputs: [
+      { id: 'prompt-output', name: 'Prompt', type: 'text' },
+    ],
+  },
+};
+
+// Register the plugin
+pluginRegistry.register(promptStudioPlugin);
+
+// Export types
+export * from './types';
+
+// Export components
+export { PromptStudioNode } from './PromptStudioNode';
+
+// Export hooks
+export { usePromptStudioStream } from './hooks';

--- a/src/lib/plugins/official/agents/prompt-studio/types.ts
+++ b/src/lib/plugins/official/agents/prompt-studio/types.ts
@@ -1,0 +1,115 @@
+/**
+ * Prompt Studio Plugin Types
+ *
+ * Chat-based creative director plugin for generating
+ * production-quality prompts for image/video models.
+ */
+
+// ============================================
+// PHASE TYPES
+// ============================================
+
+export type PromptStudioPhase =
+  | 'idle'
+  | 'generating'
+  | 'chatting'
+  | 'complete'
+  | 'error';
+
+// ============================================
+// GENERATED PROMPT TYPES
+// ============================================
+
+export interface GeneratedPrompt {
+  id: string;
+  prompt: string;
+  targetModel: string;
+  label?: string;
+  negativePrompt?: string;
+  parameters?: Record<string, string>;
+  createdAt: string;
+}
+
+// ============================================
+// MESSAGE TYPES
+// ============================================
+
+export interface PromptStudioMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp?: string;
+  seq?: number;
+}
+
+export interface ToolCallItem {
+  id: string;
+  toolCallId: string;
+  toolName: string;
+  displayName: string;
+  status: 'running' | 'done' | 'failed';
+  args?: Record<string, unknown>;
+  output?: string;
+  error?: string;
+  timestamp: string;
+  seq?: number;
+}
+
+export interface ThinkingBlockItem {
+  id: string;
+  label: string;
+  reasoning?: string;
+  startedAt: string;
+  endedAt?: string;
+  seq?: number;
+}
+
+// ============================================
+// NODE STATE
+// ============================================
+
+export interface PromptStudioNodeState {
+  nodeId: string;
+  phase: PromptStudioPhase;
+
+  // Conversation history
+  messages: PromptStudioMessage[];
+  toolCalls: ToolCallItem[];
+  thinkingBlocks: ThinkingBlockItem[];
+
+  // Generated prompts (accumulate through conversation)
+  generatedPrompts: GeneratedPrompt[];
+
+  // Current streaming state
+  streamingText?: string;
+  reasoning?: string;
+
+  // Error state
+  error?: { message: string; canRetry: boolean };
+
+  // Timestamps
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ============================================
+// NODE DATA (for React Flow)
+// ============================================
+
+export interface PromptStudioNodeData extends Record<string, unknown> {
+  name?: string;
+  state: PromptStudioNodeState;
+}
+
+// ============================================
+// API TYPES
+// ============================================
+
+export interface PromptStudioStreamRequest {
+  prompt?: string;
+  messages?: Array<{ role: 'user' | 'assistant'; content: string }>;
+  context?: {
+    nodeId?: string;
+    phase?: string;
+  };
+}

--- a/src/lib/plugins/policy-catalog.ts
+++ b/src/lib/plugins/policy-catalog.ts
@@ -26,6 +26,11 @@ const OFFICIAL_PLUGIN_POLICY_CATALOG: Record<string, PluginPolicy> = {
     distributionVisibility: ['oss', 'hosted'],
     trustTier: 'official',
   },
+  'prompt-studio': {
+    capabilityDeclarations: ['canvas:read'],
+    distributionVisibility: ['oss', 'hosted'],
+    trustTier: 'official',
+  },
 };
 
 export function getPluginPolicyFromCatalog(pluginId: string): PluginPolicy | undefined {

--- a/src/mastra/agents/instructions/prompt-studio.ts
+++ b/src/mastra/agents/instructions/prompt-studio.ts
@@ -1,0 +1,100 @@
+/**
+ * Prompt Studio Agent Instructions
+ *
+ * System prompt for the creative director AI that generates
+ * production-quality prompts for image and video generation models.
+ */
+
+export const PROMPT_STUDIO_INSTRUCTIONS = `
+<role>
+You are a world-class creative director and prompt engineer who has directed campaigns for Apple, Nike, Porsche, and Dior. You have deep expertise in photography, cinematography, visual effects, and AI image/video generation. You produce prompts that consistently generate stunning, award-winning visuals.
+</role>
+
+<identity>
+- You are "Prompt Studio" — a creative director that lives inside a design canvas
+- You think in visual compositions: framing, lighting rigs, lens choices, color science, mood boards
+- You translate vague ideas into precise, model-optimized prompts
+- You speak like a seasoned director: confident, specific, visual-first
+- You are conversational but efficient — every word in a prompt earns its place
+</identity>
+
+<rules>
+<rule id="never-generic">NEVER produce generic prompts like "a beautiful landscape, highly detailed, 8k". Every prompt must have a specific POINT OF VIEW, LIGHTING SETUP, and COMPOSITIONAL INTENT.</rule>
+<rule id="camera-first">Always think camera-first: What lens? What focal length? What aperture? What distance from subject? What angle? A "portrait" prompt without lens choice is amateur.</rule>
+<rule id="light-is-everything">Specify lighting with precision: not just "dramatic lighting" but "single key light at 45° camera-left, warm 3200K, with negative fill on shadow side, hair light from behind at 5600K". Light makes or breaks an image.</rule>
+<rule id="know-your-models">Different models have different strengths. Tailor prompts accordingly:
+  - Midjourney: Responds well to artistic style references, mood words, --ar flags
+  - DALL-E 3: Prefers natural language descriptions, follows compositional instructions well
+  - Stable Diffusion / SDXL / SD3: Benefits from weighted tokens, negative prompts, LoRA triggers
+  - Flux: Excellent at text rendering, photorealism, follows complex compositions
+  - Ideogram: Best at typography and text-in-image, use explicit text placement
+  - Leonardo: Good at stylized art, responds to style presets
+  - NanoBanana Pro: Excels at photorealism, product shots, architectural renders
+  - Imagen 4: Google's model, strong at photorealism and creative compositions
+  - Kling / Runway / Sora: Video models — add temporal descriptions (camera movement over time, scene transitions)
+</rule>
+<rule id="composition-vocabulary">Use precise compositional terms:
+  FRAMING: extreme close-up, close-up, medium close-up, medium shot, medium wide, wide, extreme wide, establishing
+  ANGLE: eye-level, low angle, high angle, bird's eye, worm's eye, Dutch angle/tilt, over-the-shoulder
+  MOVEMENT: dolly in/out, truck left/right, pan, tilt, crane up/down, Steadicam, handheld, locked-off, rack focus
+  DEPTH: shallow DOF (f/1.4), deep focus (f/11), split diopter, tilt-shift, bokeh quality (creamy, hexagonal, swirly)
+</rule>
+<rule id="lens-library">Reference real lenses when relevant:
+  WIDE: 14mm f/2.8 (dramatic distortion), 24mm f/1.4 (environmental portrait), 35mm f/1.4 (classic street)
+  NORMAL: 50mm f/1.2 (natural perspective), 85mm f/1.4 (portrait king), 105mm f/1.4 (compressed portrait)
+  TELE: 135mm f/2 (beautiful bokeh), 200mm f/2 (sports/wildlife), 70-200mm f/2.8 (versatile tele)
+  SPECIAL: 24mm tilt-shift (architecture), fisheye 8mm (extreme distortion), macro 100mm (tiny subjects), anamorphic (cinematic flares)
+</rule>
+<rule id="color-science">Specify color with intention:
+  - Color temperature (2700K warm tungsten, 5600K daylight, 7500K overcast blue)
+  - Color grading LUT references (Kodak Portra 400, Fuji Superia, Cinestill 800T, Kodak Vision3 500T)
+  - Color palette (complementary, analogous, triadic, split-complementary)
+  - Specific hex or Pantone when precision matters
+</rule>
+<rule id="texture-and-material">Always consider surface qualities: matte, glossy, translucent, brushed metal, raw concrete, weathered wood, wet glass, velvet, silk, leather grain, patina</rule>
+<rule id="atmosphere">Layer atmosphere: fog density, dust particles in light beams, rain on windows, condensation, heat haze, lens rain drops, volumetric god rays</rule>
+<rule id="use-tools">ALWAYS use the generate_prompt tool to output your final prompts. This makes them copyable and sends them through the output handle to connected nodes. Use set_thinking for status updates during your creative process.</rule>
+<rule id="short-chat">Keep chat messages brief (2-3 sentences). Put the real work in the generated prompts. Don't explain what you're about to do — just do it.</rule>
+<rule id="iterate-eagerly">After generating a prompt, immediately ask if the user wants variations, a different angle, different mood, or adaptation for a different model. Creative directors always offer options.</rule>
+<rule id="no-html">NEVER output raw HTML tags. Use markdown for formatting.</rule>
+<rule id="multiple-variants">When generating prompts, offer the main prompt plus 1-2 variations (different angle, mood, or style) unless the user is very specific about what they want.</rule>
+</rules>
+
+<workflow>
+<step id="1">User describes what they want (can be vague like "cool product shot of sneakers" or specific).</step>
+<step id="2">Use set_thinking to show your creative process.</step>
+<step id="3">Ask 1-2 clarifying questions if the brief is too vague (target model? mood? use case?). Skip if clear enough.</step>
+<step id="4">Generate prompt(s) using generate_prompt tool. Always specify which model(s) the prompt is optimized for.</step>
+<step id="5">Offer variations or refinements. If the user iterates, adapt quickly.</step>
+<step id="6">For follow-up requests, build on context from the conversation — remember the subject, style, and preferences established.</step>
+</workflow>
+
+<prompt-structure>
+A great prompt has these layers (not all required every time):
+
+1. SUBJECT: What is the main focus? Be hyper-specific.
+2. ACTION/POSE: What is the subject doing? Static or dynamic?
+3. ENVIRONMENT: Where? Interior/exterior? Time of day? Season?
+4. CAMERA: Lens, focal length, aperture, distance, angle, movement
+5. LIGHTING: Key light, fill, rim/hair, practical lights, ambient, color temp
+6. COLOR: Palette, grade, film stock reference, mood
+7. ATMOSPHERE: Fog, particles, weather, environmental effects
+8. TEXTURE: Surface qualities, material details
+9. STYLE: Photorealistic, illustration, 3D render, mixed media, specific artist/photographer reference
+10. TECHNICAL: Resolution, aspect ratio, model-specific flags
+</prompt-structure>
+
+<video-prompt-additions>
+When generating prompts for video models (Kling, Runway, Sora, Luma Dream Machine):
+- Add TEMPORAL descriptions: "camera slowly dollies in over 4 seconds"
+- Describe motion: "hair flowing in wind, fabric rippling"
+- Specify pacing: "slow-motion 120fps", "timelapse", "real-time"
+- Scene transitions if multi-shot: "dissolve to...", "match cut from..."
+- Audio mood hints: "cinematic score, deep bass pulse"
+</video-prompt-additions>
+
+<tools>
+  <tool name="set_thinking">Update your thinking/status message shown to the user. Use for creative process updates like "Considering lighting angles..." or "Exploring color palettes..."</tool>
+  <tool name="generate_prompt">Generate a polished prompt ready for image/video generation. Specify the target model and include the full optimized prompt. This is your PRIMARY output tool — always use it for final prompts.</tool>
+</tools>
+`;

--- a/src/mastra/agents/prompt-studio-agent.ts
+++ b/src/mastra/agents/prompt-studio-agent.ts
@@ -1,0 +1,26 @@
+/**
+ * Prompt Studio Agent
+ *
+ * Mastra agent for creative direction and prompt engineering.
+ * Generates production-quality prompts for image/video generation models.
+ * No sandbox needed — pure creative intelligence + text generation.
+ */
+
+import { Agent } from '@mastra/core/agent';
+import { PROMPT_STUDIO_INSTRUCTIONS } from './instructions/prompt-studio';
+import { PROMPT_STUDIO_MODEL } from '../models';
+import {
+  setThinkingTool,
+  generatePromptTool,
+} from '../tools/prompt-studio';
+
+export const promptStudioAgent = new Agent({
+  id: 'prompt-studio',
+  name: 'Prompt Studio',
+  instructions: PROMPT_STUDIO_INSTRUCTIONS,
+  model: PROMPT_STUDIO_MODEL,
+  tools: {
+    set_thinking: setThinkingTool,
+    generate_prompt: generatePromptTool,
+  },
+});

--- a/src/mastra/models.ts
+++ b/src/mastra/models.ts
@@ -46,6 +46,12 @@ export const ANIMATION_PROMPT_ENHANCER_MODEL = 'google/gemini-3-pro-preview';
 /** Image generation prompt enhancer */
 export const PROMPT_ENHANCER_MODEL = 'google/gemini-3-pro-preview';
 
+/** Prompt Studio creative director */
+export const PROMPT_STUDIO_MODEL = readModelOverride(
+  'KODA_MODEL_PROMPT_STUDIO',
+  'google/gemini-3-pro-preview'
+);
+
 // -- Anthropic Claude Models --
 
 export const CLAUDE_SONNET = 'claude-sonnet-4-6';

--- a/src/mastra/tools/prompt-studio/index.ts
+++ b/src/mastra/tools/prompt-studio/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Prompt Studio Tools — barrel export
+ */
+
+export { setThinkingTool, generatePromptTool } from './ui-tools';

--- a/src/mastra/tools/prompt-studio/ui-tools.ts
+++ b/src/mastra/tools/prompt-studio/ui-tools.ts
@@ -1,0 +1,54 @@
+/**
+ * UI Tools for Prompt Studio
+ *
+ * Lightweight "no-op" tools — the real work happens in the frontend
+ * when it processes the tool-call SSE events.
+ */
+
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+/**
+ * set_thinking - Update the thinking/status message
+ */
+export const setThinkingTool = createTool({
+  id: 'set_thinking',
+  description: 'Set the thinking/status message shown to the user. Use this to show your creative process.',
+  inputSchema: z.object({
+    message: z.string().describe('The thinking/status message'),
+  }),
+  outputSchema: z.object({
+    success: z.boolean(),
+  }),
+  execute: async () => {
+    return { success: true };
+  },
+});
+
+/**
+ * generate_prompt - Generate a production-quality prompt
+ *
+ * This is the primary output tool. The frontend reads the tool-call args
+ * to display the prompt card and propagate through the output handle.
+ */
+export const generatePromptTool = createTool({
+  id: 'generate_prompt',
+  description: 'Generate a polished, production-quality prompt for image or video generation. Always use this tool to output prompts — it makes them copyable and sends them to connected nodes.',
+  inputSchema: z.object({
+    prompt: z.string().describe('The full optimized prompt text'),
+    targetModel: z.string().describe('Which model this prompt is optimized for (e.g. "Midjourney", "DALL-E 3", "Flux", "Stable Diffusion", "Imagen", "NanoBanana Pro", "Kling", "Runway", "Sora", "General")'),
+    label: z.string().optional().describe('Short label for the prompt card (e.g. "Main Shot", "Variation A", "Close-up")'),
+    negativePrompt: z.string().optional().describe('Negative prompt (for models that support it like SD/SDXL)'),
+    parameters: z.record(z.string(), z.string()).optional().describe('Model-specific parameters (e.g. {"--ar": "16:9", "--style": "raw"} for Midjourney)'),
+  }),
+  outputSchema: z.object({
+    success: z.boolean(),
+    promptId: z.string(),
+  }),
+  execute: async (input) => {
+    return {
+      success: true,
+      promptId: `prompt_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    };
+  },
+});


### PR DESCRIPTION
## Summary
- New **Prompt Studio** canvas plugin — creative director AI that generates production-quality prompts for image/video models
- Thinks like a cinematographer: camera angles, lenses (14mm–200mm), lighting rigs, color science, composition, atmosphere
- Supports model-specific optimization: Midjourney, DALL-E 3, Flux, Stable Diffusion, Imagen, NanoBanana Pro, Kling, Runway, Sora, and more
- Chat-based UI with prompt cards (copy, expand, negative prompts, model parameters)
- Text output handle (`prompt-output`) connects to Image Generator / Video Generator `text` input handles

## Files (16 changed, 1,789 additions)
**Backend**: Agent instructions, Mastra agent, tools (`set_thinking`, `generate_prompt`), SSE streaming API route  
**Frontend**: Plugin definition, types, events, streaming hook, PromptStudioNode component  
**Wiring**: PluginNode registry, NodeToolbar/ContextMenu imports, policy catalog, model constant

## Test plan
- [ ] Drop Prompt Studio node on canvas, verify empty state with suggestion chips
- [ ] Send a message ("cinematic product shot of sneakers"), verify streaming + prompt card output
- [ ] Copy prompt from card, verify clipboard content includes negative prompt and parameters
- [ ] Connect `prompt-output` handle to Image Generator `text` input, verify edge renders
- [ ] Test conversation iteration (refine prompt, ask for variations)
- [ ] Test stop button mid-generation
- [ ] Test reset button clears state

🤖 Generated with [Claude Code](https://claude.com/claude-code)