### PR TITLE
fix(prompt-studio): add to toolbar and context menu

### DIFF
--- a/src/components/canvas/ContextMenu.tsx
+++ b/src/components/canvas/ContextMenu.tsx
@@ -256,6 +256,16 @@ export function ContextMenu({ onPluginLaunch }: ContextMenuProps) {
           ),
           keywords: ['svg', 'vector', 'icon', 'logo'],
         },
+        {
+          id: 'promptStudio',
+          icon: <Sparkle className="h-4 w-4 text-amber-400" />,
+          label: 'Prompt Studio',
+          action: () => handleAddNode(
+            (pos, name) => createPluginNode(pos, 'prompt-studio', name),
+            'Prompt Studio'
+          ),
+          keywords: ['prompt', 'creative', 'director', 'enhance', 'image prompt', 'video prompt'],
+        },
       ],
     },
     {

--- a/src/components/canvas/NodeToolbar.tsx
+++ b/src/components/canvas/NodeToolbar.tsx
@@ -219,6 +219,16 @@ export function NodeToolbar({ onPluginLaunch }: NodeToolbarProps) {
           ),
           keywords: ['svg', 'vector', 'icon', 'logo'],
         },
+        {
+          id: 'promptStudio',
+          icon: <Sparkle className="h-4 w-4 text-amber-400" />,
+          label: 'Prompt Studio',
+          action: () => handleAddNode(
+            (pos, name) => createPluginNode(pos, 'prompt-studio', name),
+            'Prompt Studio'
+          ),
+          keywords: ['prompt', 'creative', 'director', 'enhance', 'image prompt', 'video prompt'],
+        },
       ],
     },
     {


### PR DESCRIPTION
## Summary
- Add Prompt Studio to the hardcoded menu items in NodeToolbar and ContextMenu
- Plugin was registered but not showing in the add node dropdown

## Test plan
- [ ] Open add node menu (+), verify "Prompt Studio" appears under NODES with amber sparkle icon
- [ ] Right-click canvas, verify "Prompt Studio" appears in context menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)