### PR TITLE
feat(templates): read-only preview with remix flow

### DIFF
--- a/src/app/template/[id]/page.tsx
+++ b/src/app/template/[id]/page.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { use, useEffect, useState, useCallback } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { ReactFlowProvider } from '@xyflow/react';
+import { Canvas } from '@/components/canvas/Canvas';
+import { AppShell } from '@/components/layout';
+import { RemixBanner } from '@/components/template/RemixBanner';
+import { useAppStore } from '@/stores/app-store';
+import { useCanvasStore } from '@/stores/canvas-store';
+import { getTemplate, getShowcaseTemplate } from '@/lib/templates';
+import type { Template } from '@/lib/templates/types';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+interface TemplatePageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default function TemplatePage({ params }: TemplatePageProps) {
+  const { id } = use(params);
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [template, setTemplate] = useState<Template | null>(null);
+  const [isRemixing, setIsRemixing] = useState(false);
+
+  const loadAsReadOnly = useCanvasStore((state) => state.loadAsReadOnly);
+  const loadCanvasData = useCanvasStore((state) => state.loadCanvasData);
+  const createCanvasFromTemplate = useAppStore((state) => state.createCanvasFromTemplate);
+
+  // Load template and set canvas to read-only
+  useEffect(() => {
+    async function load() {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        let tmpl = getTemplate(id);
+        if (!tmpl) {
+          tmpl = await getShowcaseTemplate(id);
+        }
+        if (!tmpl) {
+          setError('Template not found');
+          return;
+        }
+
+        setTemplate(tmpl);
+        loadAsReadOnly(tmpl.nodes, tmpl.edges);
+      } catch (err) {
+        console.error('Failed to load template:', err);
+        setError('Failed to load template');
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    load();
+  }, [id, loadAsReadOnly]);
+
+  // Cleanup on unmount: clear read-only state
+  useEffect(() => {
+    return () => {
+      loadCanvasData([], []);
+    };
+  }, [loadCanvasData]);
+
+  const handleRemix = useCallback(async () => {
+    if (!template) return;
+    setIsRemixing(true);
+    try {
+      const canvasId = await createCanvasFromTemplate(template);
+      router.push(`/canvas/${canvasId}`);
+    } catch {
+      toast.error('Failed to remix template');
+      setIsRemixing(false);
+    }
+  }, [template, createCanvasFromTemplate, router]);
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col h-screen bg-background">
+        <div className="flex-1 flex items-center justify-center">
+          <div className="flex flex-col items-center gap-4 text-muted-foreground">
+            <Loader2 className="h-8 w-8 animate-spin" />
+            <p>Loading template...</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !template) {
+    return (
+      <div className="flex flex-col h-screen bg-background">
+        <div className="flex-1 flex items-center justify-center">
+          <div className="flex flex-col items-center gap-4">
+            <div className="text-6xl">🖼️</div>
+            <h1 className="font-serif text-xl font-normal text-foreground">
+              {error || 'Template not found'}
+            </h1>
+            <p className="text-muted-foreground">
+              The template you&apos;re looking for doesn&apos;t exist.
+            </p>
+            <Link
+              href="/"
+              className="mt-4 px-4 py-2 bg-[#3b82f6] hover:bg-[#2563eb] text-white rounded-lg transition-colors"
+            >
+              Go to Dashboard
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <ReactFlowProvider>
+      <AppShell
+        mode="canvas"
+        canvasName={template.name}
+        showSidebar={false}
+      >
+        <RemixBanner
+          templateName={template.name}
+          onRemix={handleRemix}
+          isRemixing={isRemixing}
+        />
+        <div className="h-full">
+          <Canvas />
+        </div>
+      </AppShell>
+    </ReactFlowProvider>
+  );
+}

--- a/src/components/canvas/Canvas.tsx
+++ b/src/components/canvas/Canvas.tsx
@@ -46,6 +46,7 @@ export function Canvas() {
   const setActiveTool = useCanvasStore((state) => state.setActiveTool);
   const deleteSelectedEdges = useCanvasStore((state) => state.deleteSelectedEdges);
   const selectedEdgeIds = useCanvasStore((state) => state.selectedEdgeIds);
+  const isReadOnly = useCanvasStore((state) => state.isReadOnly);
   const setReactFlowInstance = useCanvasStore((state) => state.setReactFlowInstance);
 
   // Plugin sandbox state
@@ -238,29 +239,33 @@ export function Canvas() {
 
   return (
     <div ref={containerRef} className="w-full h-full relative" style={{ backgroundColor: 'var(--canvas-bg)' }} onMouseMove={handleMouseMove}>
-      <NodeToolbar onPluginLaunch={handlePluginLaunch} />
-      <WelcomeOverlay onPluginLaunch={handlePluginLaunch} />
-      <SettingsPanel />
-      <VideoSettingsPanel />
-      <ContextMenu onPluginLaunch={handlePluginLaunch} />
-      <KeyboardShortcuts />
+      {!isReadOnly && (
+        <>
+          <NodeToolbar onPluginLaunch={handlePluginLaunch} />
+          <WelcomeOverlay onPluginLaunch={handlePluginLaunch} />
+          <SettingsPanel />
+          <VideoSettingsPanel />
+          <ContextMenu onPluginLaunch={handlePluginLaunch} />
+          <KeyboardShortcuts />
+        </>
+      )}
       {activePlugin && (
         <AgentSandbox plugin={activePlugin} onClose={closeSandbox} />
       )}
       <ReactFlow
         nodes={nodes}
         edges={edges}
-        onNodesChange={onNodesChange}
-        onEdgesChange={onEdgesChange}
-        onConnect={onConnect}
-        onSelectionChange={onSelectionChange}
-        onSelectionEnd={onSelectionEnd}
+        onNodesChange={isReadOnly ? undefined : onNodesChange}
+        onEdgesChange={isReadOnly ? undefined : onEdgesChange}
+        onConnect={isReadOnly ? undefined : onConnect}
+        onSelectionChange={isReadOnly ? undefined : onSelectionChange}
+        onSelectionEnd={isReadOnly ? undefined : onSelectionEnd}
         onPaneClick={handlePaneClick}
-        onContextMenu={handleContextMenu}
+        onContextMenu={isReadOnly ? undefined : handleContextMenu}
         onInit={setReactFlowInstance}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
-        isValidConnection={isValidConnection}
+        isValidConnection={isReadOnly ? undefined : isValidConnection}
         fitView
         className={`tool-${activeTool}`}
         style={{ backgroundColor: 'var(--canvas-bg)' }}
@@ -273,16 +278,18 @@ export function Canvas() {
         proOptions={{ hideAttribution: true }}
         snapToGrid={useSettingsStore.getState().canvasPreferences.gridSnap}
         snapGrid={[20, 20]}
-        panOnDrag={activeTool === 'pan'}
+        panOnDrag={isReadOnly ? true : activeTool === 'pan'}
         panOnScroll={false}
         zoomOnScroll
         minZoom={0.25}
-        selectionOnDrag={activeTool === 'select' || activeTool === 'scissors'}
+        nodesDraggable={!isReadOnly}
+        nodesConnectable={!isReadOnly}
+        edgesReconnectable={!isReadOnly}
+        selectionOnDrag={isReadOnly ? false : activeTool === 'select' || activeTool === 'scissors'}
         selectionMode={SelectionMode.Partial}
-        edgesReconnectable
-        deleteKeyCode={['Backspace', 'Delete']}
+        deleteKeyCode={isReadOnly ? [] : ['Backspace', 'Delete']}
         connectionRadius={30}
-        selectNodesOnDrag={activeTool === 'select'}
+        selectNodesOnDrag={isReadOnly ? false : activeTool === 'select'}
       >
         <Background
           variant={BackgroundVariant.Dots}

--- a/src/components/dashboard/hooks/useDashboardState.ts
+++ b/src/components/dashboard/hooks/useDashboardState.ts
@@ -4,7 +4,7 @@ import { useEffect, useState, useCallback, useRef } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { toast } from 'sonner';
 import { useAppStore } from '@/stores/app-store';
-import { getTemplate, getShowcaseTemplateMetadata, getShowcaseTemplate } from '@/lib/templates';
+import { getShowcaseTemplateMetadata } from '@/lib/templates';
 import type { TemplateMetadata } from '@/lib/templates/types';
 
 export type TabType = 'my-spaces' | 'shared' | 'templates';
@@ -72,7 +72,6 @@ export function useDashboardState(): DashboardState {
   const isLoadingList = useAppStore((state) => state.isLoadingList);
   const loadCanvasList = useAppStore((state) => state.loadCanvasList);
   const createCanvas = useAppStore((state) => state.createCanvas);
-  const createCanvasFromTemplate = useAppStore((state) => state.createCanvasFromTemplate);
   const renameCanvas = useAppStore((state) => state.renameCanvas);
   const duplicateCanvas = useAppStore((state) => state.duplicateCanvas);
   const deleteCanvas = useAppStore((state) => state.deleteCanvas);
@@ -228,31 +227,20 @@ export function useDashboardState(): DashboardState {
   }, [createCanvas, router]);
 
   const handleSelectTemplate = useCallback(async (templateId: string) => {
-    setIsCreating(true);
-    try {
-      // Check built-in templates first, then showcase templates
-      let template = getTemplate(templateId);
-      if (!template) {
-        template = await getShowcaseTemplate(templateId);
-      }
-      if (!template) {
-        toast.error('Template not found');
-        setIsCreating(false);
-        return;
-      }
-
-      if (templateId === 'blank') {
+    if (templateId === 'blank') {
+      setIsCreating(true);
+      try {
         const id = await createCanvas('Untitled Canvas');
         router.push(`/canvas/${id}`);
-      } else {
-        const id = await createCanvasFromTemplate(template);
-        router.push(`/canvas/${id}`);
+      } catch {
+        toast.error('Failed to create canvas');
+        setIsCreating(false);
       }
-    } catch {
-      toast.error('Failed to create canvas from template');
-      setIsCreating(false);
+    } else {
+      // Non-blank templates open in read-only preview mode
+      router.push(`/template/${templateId}`);
     }
-  }, [createCanvas, createCanvasFromTemplate, router]);
+  }, [createCanvas, router]);
 
   const handleRename = useCallback(async (id: string, name: string) => {
     try {

--- a/src/components/template/RemixBanner.tsx
+++ b/src/components/template/RemixBanner.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { Loader2, Sparkles } from 'lucide-react';
+
+interface RemixBannerProps {
+  templateName: string;
+  onRemix: () => void;
+  isRemixing: boolean;
+}
+
+export function RemixBanner({ templateName, onRemix, isRemixing }: RemixBannerProps) {
+  return (
+    <div className="mx-4 mt-3 flex items-center justify-between rounded-lg border border-blue-500/40 bg-blue-500/10 px-4 py-2.5">
+      <div className="flex items-center gap-3">
+        <span className="text-sm font-medium text-blue-200">{templateName}</span>
+        <span className="rounded-full bg-blue-500/20 px-2 py-0.5 text-xs font-medium text-blue-300">
+          Preview
+        </span>
+      </div>
+      <button
+        onClick={onRemix}
+        disabled={isRemixing}
+        className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-1.5 text-sm font-medium text-white transition-colors hover:bg-blue-500 disabled:opacity-50"
+      >
+        {isRemixing ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <Sparkles className="h-4 w-4" />
+        )}
+        {isRemixing ? 'Remixing...' : 'Remix'}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Templates now open in a read-only preview at `/template/{id}` instead of immediately cloning into a new canvas
- Users can explore the template, then click "Remix" to create their own editable copy
- Canvas component respects `isReadOnly` from the store — hides toolbar, settings panels, context menu, keyboard shortcuts, and disables drag/connect/delete

## Changes
- **New** `src/app/template/[id]/page.tsx` — template preview page using `loadAsReadOnly()`
- **New** `src/components/template/RemixBanner.tsx` — blue banner with template name, "Preview" badge, and "Remix" button
- **Modified** `src/components/canvas/Canvas.tsx` — `isReadOnly` guards on editing UI and ReactFlow interaction props
- **Modified** `src/components/dashboard/hooks/useDashboardState.ts` — non-blank templates route to `/template/{id}` instead of creating a canvas

## Test plan
- [ ] Click any non-blank template on dashboard → navigates to `/template/{id}`, canvas is read-only
- [ ] Verify nodes are not draggable, no context menu, no toolbar, no keyboard shortcuts
- [ ] Verify pan and zoom still work
- [ ] Click "Remix" → creates new canvas, navigates to `/canvas/{id}`, fully editable
- [ ] Click blank template → still creates canvas directly (unchanged behavior)
- [ ] Browser back from template preview → returns to dashboard
- [ ] Refresh on `/template/{id}` → still works
- [ ] Invalid template ID → shows error page with dashboard link

🤖 Generated with [Claude Code](https://claude.com/claude-code)