### PR TITLE
fix: duplicated image node no longer inherits loading state

### DIFF
--- a/src/stores/canvas-store.test.ts
+++ b/src/stores/canvas-store.test.ts
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+type LocalStorageMock = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+  clear: () => void;
+};
+
+function createLocalStorageMock(): LocalStorageMock {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+  };
+}
+
+test('resetTransientNodeStateForDuplicate clears in-flight image generation state', async () => {
+  (globalThis as { localStorage?: LocalStorageMock }).localStorage = createLocalStorageMock();
+
+  const { createImageGeneratorNode, resetTransientNodeStateForDuplicate } = await import('./canvas-store');
+
+  const source = createImageGeneratorNode({ x: 10, y: 20 });
+  const loadingNode = {
+    ...source,
+    data: {
+      ...source.data,
+      prompt: 'hero product shot',
+      isGenerating: true,
+      error: 'Network timeout',
+    },
+  };
+
+  const duplicated = resetTransientNodeStateForDuplicate(loadingNode);
+
+  assert.equal(duplicated.type, 'imageGenerator');
+  assert.equal(duplicated.data.isGenerating, false);
+  assert.equal(duplicated.data.error, undefined);
+  assert.equal(duplicated.data.prompt, 'hero product shot');
+});
+
+test('resetTransientNodeStateForDuplicate leaves non-image nodes untouched', async () => {
+  (globalThis as { localStorage?: LocalStorageMock }).localStorage = createLocalStorageMock();
+
+  const { createTextNode, resetTransientNodeStateForDuplicate } = await import('./canvas-store');
+
+  const textNode = createTextNode({ x: 0, y: 0 });
+  const duplicated = resetTransientNodeStateForDuplicate(textNode);
+
+  assert.equal(duplicated, textNode);
+});

--- a/src/stores/canvas-store.ts
+++ b/src/stores/canvas-store.ts
@@ -155,6 +155,24 @@ const cloneSnapshot = (nodes: AppNode[], edges: AppEdge[]): HistorySnapshot => (
   edges: JSON.parse(JSON.stringify(edges)),
 });
 
+/**
+ * Clear transient runtime state when duplicating nodes.
+ * Prevents cloned nodes from inheriting in-flight generation UI state.
+ */
+export const resetTransientNodeStateForDuplicate = (node: AppNode): AppNode => {
+  if (node.type !== 'imageGenerator') return node;
+
+  const data = node.data as ImageGeneratorNodeData;
+  return {
+    ...node,
+    data: {
+      ...data,
+      isGenerating: false,
+      error: undefined,
+    },
+  };
+};
+
 // Default node creators
 export const createImageGeneratorNode = (position: { x: number; y: number }, name?: string): AppNode => ({
   id: generateId(),
@@ -628,7 +646,7 @@ export const useCanvasStore = create<CanvasState>()(
         const newNodes = clonedNodes.map((node) => {
           const newId = generateId();
           idMap.set(node.id, newId);
-          return {
+          return resetTransientNodeStateForDuplicate({
             ...node,
             id: newId,
             position: {
@@ -636,7 +654,7 @@ export const useCanvasStore = create<CanvasState>()(
               y: node.position.y + offsetY,
             },
             selected: true,
-          };
+          });
         });
         const remappedNodes = newNodes.map((node) => {
           if (node.type !== 'group') return node;


### PR DESCRIPTION
## Summary
- reset transient image generation state during node duplication
- ensure duplicated image nodes start with `isGenerating: false` and cleared error state
- add regression tests for duplication state sanitization

## Testing
- `npx tsx --test src/stores/canvas-store.test.ts`

Closes #106
