### PR TITLE
Improve animation node layout and chat input

### DIFF
--- a/src/lib/plugins/official/agents/animation-generator/AnimationNode.tsx
+++ b/src/lib/plugins/official/agents/animation-generator/AnimationNode.tsx
@@ -2398,12 +2398,12 @@ function AnimationNodeComponent({ id, data, selected }: AnimationNodeProps) {
 
   // ─── Node styling ──────────────────────────────────────────────────
   const nodeClasses = useMemo(() => {
-    const base = 'node-drag-handle node-drag-surface animation-node w-[400px] min-h-[520px] max-h-[720px] rounded-xl overflow-hidden flex flex-col';
+    const base = 'node-drag-handle node-drag-surface animation-node w-[420px] rounded-2xl overflow-hidden flex flex-col shadow-[var(--node-card-shadow)]';
     if (selected) return `${base} ring-1 ring-[var(--an-accent)]/70`;
     return base;
   }, [selected]);
   const summaryContainerClass = useMemo(() => {
-    const base = 'node-drag-handle node-drag-surface animation-node w-[400px] rounded-xl overflow-hidden flex flex-col';
+    const base = 'node-drag-handle node-drag-surface animation-node w-[420px] rounded-2xl overflow-hidden flex flex-col shadow-[var(--node-card-shadow)]';
     return selected ? `${base} ring-1 ring-[var(--an-accent)]/70` : base;
   }, [selected]);
   const latestVersion = state.versions?.[state.versions.length - 1];
@@ -2428,9 +2428,17 @@ function AnimationNodeComponent({ id, data, selected }: AnimationNodeProps) {
   // minHeight must accommodate: all handles + padding
   const lastVideoHandleBottom = svgCodeHandleTop + HANDLE_SPACING;
   const minHeight = Math.max(200, lastVideoHandleBottom);
+  const nodeHeight = Math.max(620, minHeight);
+  const shouldForceFullDisplay = state.phase !== 'idle'
+    || state.messages.length > 0
+    || media.length > 0
+    || !!state.plan
+    || !!latestVersion?.videoUrl
+    || !!state.output?.videoUrl;
+  const resolvedDisplayMode = shouldForceFullDisplay ? 'full' : displayMode;
 
   // ─── Render ─────────────────────────────────────────────────────────
-  if (displayMode !== 'full') {
+  if (resolvedDisplayMode !== 'full') {
     return (
       <div className="relative" {...focusProps}>
         <div className="mb-2 rounded-xl px-3 py-2 text-sm font-medium" style={{ color: 'var(--node-title-animation)' }}>
@@ -2439,7 +2447,7 @@ function AnimationNodeComponent({ id, data, selected }: AnimationNodeProps) {
         </div>
 
         <div className={summaryContainerClass} style={{ minHeight }}>
-          <div className={`node-body flex-1 ${displayMode === 'compact' ? 'node-compact' : 'node-summary'}`}>
+          <div className={`node-body flex-1 ${resolvedDisplayMode === 'compact' ? 'node-compact' : 'node-summary'}`}>
             <div className="node-content-area rounded-xl p-3">
               <p className="text-xs font-medium text-[var(--an-text-muted)]">
                 {headerConfig.statusText}
@@ -2556,7 +2564,7 @@ function AnimationNodeComponent({ id, data, selected }: AnimationNodeProps) {
     <div
       ref={nodeContainerRef}
       className={`${nodeClasses}${isDragOver ? ' ring-1 ring-blue-500/50' : ''}`}
-      style={{ minHeight }}
+      style={{ minHeight, height: nodeHeight }}
       onDragOver={(e) => {
         e.preventDefault();
         e.stopPropagation();
@@ -2574,11 +2582,27 @@ function AnimationNodeComponent({ id, data, selected }: AnimationNodeProps) {
       }}
     >
       {/* ── Header ───────────────────────────────────────────────────── */}
-      <div className="flex-shrink-0 flex items-center gap-2 px-3.5 py-2 border-b border-[var(--an-border)]">
-        <div className="flex-1 min-w-0">
-          <p className="text-[10px] leading-tight" style={{ color: headerConfig.statusColor }}>
-            {headerConfig.statusText}
-          </p>
+      <div className="flex-shrink-0 border-b border-[var(--an-border)] bg-[var(--an-bg-card)] px-4 py-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="text-[10px] uppercase tracking-[0.14em] text-[var(--an-text-dim)]">
+              Animation Workspace
+            </p>
+            <p className="mt-1 text-[12px] font-medium leading-tight" style={{ color: headerConfig.statusColor }}>
+              {headerConfig.statusText}
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center justify-end gap-1.5 text-[10px] text-[var(--an-text-dim)]">
+            <span className="rounded-full border border-[var(--an-border-input)] bg-[var(--an-bg)] px-2 py-1">
+              {engine === 'remotion' ? 'Remotion' : 'Theatre'}
+            </span>
+            <span className="rounded-full border border-[var(--an-border-input)] bg-[var(--an-bg)] px-2 py-1">
+              {aspectRatio}
+            </span>
+            <span className="rounded-full border border-[var(--an-border-input)] bg-[var(--an-bg)] px-2 py-1">
+              {duration}s
+            </span>
+          </div>
         </div>
       </div>
 
@@ -2586,11 +2610,11 @@ function AnimationNodeComponent({ id, data, selected }: AnimationNodeProps) {
       {hasTimelineContent && (
         <div
           ref={chatScrollRef}
-          className="nowheel nopan nodrag cursor-text select-text flex-1 overflow-y-auto overflow-x-hidden min-h-0 scrollbar-hidden"
+          className="nowheel nopan nodrag cursor-text select-text flex-1 overflow-y-auto overflow-x-hidden min-h-0 scrollbar-hidden bg-[linear-gradient(180deg,var(--an-bg)_0%,var(--an-bg-card)_100%)]"
           style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' } as React.CSSProperties}
           onWheel={(e) => { if (!e.ctrlKey) e.stopPropagation(); }}
         >
-          <div className="px-3.5 py-2.5 space-y-2.5">
+          <div className="px-4 py-3 space-y-3">
             {/* Timeline items - messages, plan, and videos in chronological order */}
             {timeline.map((item, idx) => {
               if (item.kind === 'user') {
@@ -2806,18 +2830,22 @@ function AnimationNodeComponent({ id, data, selected }: AnimationNodeProps) {
 
       {/* ── Sticky todo section ──────────────────────────────────────── */}
       {state.execution?.todos && state.execution.todos.length > 0 && (
-        <div className="flex-shrink-0">
+        <div className="flex-shrink-0 border-t border-[var(--an-border)] bg-[var(--an-bg-card)] px-1.5 py-1.5">
           <TodoSection todos={state.execution.todos} />
         </div>
       )}
 
       {/* ── Media strip (thumbnails of attached media) */}
       {media.length > 0 && (
-        <div className="flex-shrink-0 px-3 py-1 border-t border-[var(--an-border)]">
-          <div className="flex gap-1 overflow-x-auto scrollbar-hidden items-center">
+        <div className="flex-shrink-0 border-t border-[var(--an-border)] bg-[var(--an-bg-card)] px-3.5 py-2">
+          <div className="mb-1.5 flex items-center justify-between text-[10px] text-[var(--an-text-dim)]">
+            <span>Attached media</span>
+            <span>{media.length} item{media.length === 1 ? '' : 's'}</span>
+          </div>
+          <div className="flex gap-1.5 overflow-x-auto scrollbar-hidden items-center">
             {media.map((m) => (
               <div key={m.id} className="relative group flex-shrink-0">
-                <div className="w-8 h-8 rounded bg-[var(--an-bg-card)] overflow-hidden border border-[var(--an-border-input)]">
+                <div className="w-10 h-10 rounded-md bg-[var(--an-bg)] overflow-hidden border border-[var(--an-border-input)]">
                   {m.type === 'image' ? (
                     <img src={m.dataUrl} alt={m.name} className="w-full h-full object-cover" />
                   ) : (
@@ -2852,7 +2880,7 @@ function AnimationNodeComponent({ id, data, selected }: AnimationNodeProps) {
       {!hasTimelineContent && <div className="flex-1" />}
 
       {/* ── Chat input (always visible) ──────────────────────────────── */}
-      <div className="shrink-0 nopan nodrag nowheel">
+      <div className="shrink-0 border-t border-[var(--an-border)] bg-[linear-gradient(180deg,var(--an-bg-card)_0%,var(--an-bg)_100%)] nopan nodrag nowheel">
         <ChatInput
           onSubmit={handleInputSubmit}
           isGenerating={isStreaming}

--- a/src/lib/plugins/official/agents/animation-generator/components/ChatInput.tsx
+++ b/src/lib/plugins/official/agents/animation-generator/components/ChatInput.tsx
@@ -9,7 +9,7 @@
 
 import React, { useState, useCallback, useRef, useEffect, KeyboardEvent } from 'react';
 import {
-  ArrowUp, Square, Paperclip, ChevronDown, ChevronUp, Image, Video, Link2, Pencil, Trash2,
+  ArrowUp, Square, Paperclip, ChevronDown, ChevronUp, Image as ImageIcon, Video, Link2, Pencil, Trash2,
   Settings,
 } from 'lucide-react';
 import {
@@ -203,10 +203,10 @@ export function ChatInput({
   const canSend = !disabled && message.trim().length > 0;
 
   return (
-    <div className="px-3 pt-2 pb-2.5 border-t border-[var(--an-border)]">
+    <div className="px-3.5 pt-3 pb-3.5">
       {/* Queued messages section */}
       {queue.length > 0 && (
-        <div className="mb-2 rounded-lg bg-[var(--an-bg-elevated)] border border-[var(--an-border-input)] overflow-hidden">
+        <div className="mb-2.5 rounded-xl bg-[var(--an-bg-elevated)] border border-[var(--an-border-input)] overflow-hidden shadow-[0_10px_24px_-20px_rgba(15,23,42,0.5)]">
           {/* Collapsible header */}
           <button
             onClick={() => setQueueExpanded(!queueExpanded)}
@@ -285,9 +285,12 @@ export function ChatInput({
       )}
 
       {/* Input box */}
-      <div className="rounded-[10px] border border-[var(--an-border-input)] overflow-hidden" style={{ backgroundColor: 'var(--an-bg-card)' }}>
+      <div
+        className="rounded-[16px] border border-[var(--an-border-input)] overflow-hidden shadow-[0_18px_44px_-28px_rgba(15,23,42,0.45)]"
+        style={{ backgroundColor: 'var(--an-bg-input)' }}
+      >
         {/* Textarea area */}
-        <div className="px-3 pt-2.5 pb-1.5">
+        <div className="px-3.5 pt-3 pb-2">
           <textarea
             ref={textareaRef}
             value={message}
@@ -296,28 +299,28 @@ export function ChatInput({
             placeholder={inputPlaceholder}
             disabled={disabled}
             rows={1}
-            className="w-full resize-none text-[13px] text-[var(--an-text)] outline-none leading-[1.4]"
-            style={{ minHeight: '20px', maxHeight: '100px', backgroundColor: 'transparent' }}
+            className="w-full resize-none text-[13px] text-[var(--an-text)] outline-none leading-[1.5] placeholder:text-[var(--an-text-placeholder)]"
+            style={{ minHeight: '48px', maxHeight: '120px', backgroundColor: 'transparent' }}
           />
         </div>
 
         {/* Bottom bar */}
-        <div className="flex items-center justify-between px-2 py-1 pb-2">
+        <div className="flex items-center justify-between gap-2 border-t border-[var(--an-border)] px-2.5 py-2.5 bg-[var(--an-bg-card)]">
           {/* Settings summary — click to open panel (hidden when no callback) */}
           {onOpenSettings ? (
             <button
               onClick={onOpenSettings}
-              className="flex items-center gap-1 px-1.5 py-1 rounded text-[10px] text-[var(--an-text-placeholder)] hover:text-[var(--an-text-muted)] transition-colors"
+              className="flex min-w-0 items-center gap-1 rounded-full border border-[var(--an-border-input)] bg-[var(--an-bg)] px-2.5 py-1.5 text-[10px] text-[var(--an-text-dim)] hover:border-[var(--an-border-hover)] hover:text-[var(--an-text-muted)] transition-colors"
               disabled={disabled}
             >
               <Settings className="w-3 h-3" />
-              <span>
+              <span className="truncate">
                 {engine === 'remotion' ? 'Remotion' : 'Theatre'} · {aspectRatio} · {duration}s
                 {techniques.length > 0 ? ` · ${techniques.length} preset${techniques.length > 1 ? 's' : ''}` : ''}
               </span>
             </button>
           ) : (
-            <div />
+            <div className="text-[10px] text-[var(--an-text-placeholder)] px-1">Enter to send</div>
           )}
 
           {/* Action buttons */}
@@ -327,7 +330,7 @@ export function ChatInput({
             <DropdownMenu open={showAttachMenu} onOpenChange={setShowAttachMenu}>
               <DropdownMenuTrigger asChild>
                 <button
-                  className="flex items-center justify-center w-7 h-7 rounded-md text-[var(--an-text-placeholder)] hover:text-[var(--an-text-dim)] transition-colors"
+                  className="flex items-center justify-center w-8 h-8 rounded-full border border-transparent text-[var(--an-text-placeholder)] hover:border-[var(--an-border-input)] hover:bg-[var(--an-bg)] hover:text-[var(--an-text-dim)] transition-colors"
                   disabled={disabled}
                 >
                   <Paperclip className="w-4 h-4" />
@@ -337,7 +340,7 @@ export function ChatInput({
                 <DropdownMenuLabel className="text-xs text-zinc-500">Add Reference</DropdownMenuLabel>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem onClick={() => handleFileSelect('image')}>
-                  <Image className="h-4 w-4 mr-2 text-teal-400" />
+                  <ImageIcon className="h-4 w-4 mr-2 text-teal-400" />
                   Upload Image
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => handleFileSelect('video')}>
@@ -351,7 +354,7 @@ export function ChatInput({
                     {availableNodeOutputs.map((node) => (
                       <DropdownMenuItem key={node.nodeId} onClick={() => handleNodeRef(node)}>
                         {node.type === 'image' ? (
-                          <Image className="h-4 w-4 mr-2 text-teal-400" />
+                          <ImageIcon className="h-4 w-4 mr-2 text-teal-400" />
                         ) : (
                           <Video className="h-4 w-4 mr-2 text-purple-400" />
                         )}
@@ -369,10 +372,10 @@ export function ChatInput({
             {isBusy && (
               <button
                 onClick={handleStop}
-                className="flex items-center justify-center w-7 h-7 rounded-full bg-[var(--an-bg-hover)] hover:bg-[var(--an-border-hover)] transition-colors"
+                className="flex items-center justify-center w-8 h-8 rounded-full border border-[var(--an-border-input)] bg-[var(--an-bg)] hover:border-[var(--an-border-hover)] hover:bg-[var(--an-bg-hover)] transition-colors"
                 title="Stop generation"
               >
-                <Square className="w-3 h-3 text-white" />
+                <Square className="w-3 h-3 text-[var(--an-text-muted)]" />
               </button>
             )}
 
@@ -380,7 +383,7 @@ export function ChatInput({
             <button
               onClick={handleSubmit}
               disabled={!canSend}
-              className={`flex items-center justify-center w-7 h-7 rounded-full transition-colors ${
+              className={`flex items-center justify-center w-8 h-8 rounded-full transition-colors shadow-sm ${
                 canSend
                   ? 'bg-[var(--an-accent)] hover:bg-[var(--an-accent-hover)]'
                   : 'bg-[var(--an-accent)] opacity-40 cursor-not-allowed'


### PR DESCRIPTION
## Summary
- keep active animation nodes in full mode so the chat UI does not disappear when the canvas zoom level drops
- give the animation node a stable full-height shell so the timeline scrolls independently and the chat input stays pinned at the bottom
- restyle the footer and chat input area to make the composer, controls, and attached media strip easier to see and use

## Verification
- `npx eslint src/lib/plugins/official/agents/animation-generator/AnimationNode.tsx src/lib/plugins/official/agents/animation-generator/components/ChatInput.tsx` *(warnings only, no errors)*