### PR TITLE
Keep animation chat input pinned above scrollable history

### DIFF
--- a/src/lib/plugins/official/agents/animation-generator/AnimationNode.tsx
+++ b/src/lib/plugins/official/agents/animation-generator/AnimationNode.tsx
@@ -2606,278 +2606,289 @@ function AnimationNodeComponent({ id, data, selected }: AnimationNodeProps) {
         </div>
       </div>
 
-      {/* ── Chat area (scrollable) ───────────────────────────────────── */}
-      {hasTimelineContent && (
-        <div
-          ref={chatScrollRef}
-          className="nowheel nopan nodrag cursor-text select-text flex-1 overflow-y-auto overflow-x-hidden min-h-0 scrollbar-hidden bg-[linear-gradient(180deg,var(--an-bg)_0%,var(--an-bg-card)_100%)]"
-          style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' } as React.CSSProperties}
-          onWheel={(e) => { if (!e.ctrlKey) e.stopPropagation(); }}
-        >
-          <div className="px-4 py-3 space-y-3">
-            {/* Timeline items - messages, plan, and videos in chronological order */}
-            {timeline.map((item, idx) => {
-              if (item.kind === 'user') {
-                return <UserBubble key={item.id} content={item.content} media={item.media} />;
-              }
-              if (item.kind === 'assistant') {
-                return <AssistantText key={item.id} content={item.content} />;
-              }
-              if (item.kind === 'plan' && state.plan) {
-                return (
-                  <PlanCard
-                    key={item.id}
-                    plan={state.plan}
-                    accepted={!!state.planAccepted}
-                    onAccept={handleAcceptPlan}
-                    onReject={handleRejectPlan}
-                  />
-                );
-              }
-              if (item.kind === 'video') {
-                // Check if this is the latest video (last video in the timeline)
-                const isLatestVideo = timeline.filter(i => i.kind === 'video').pop()?.id === item.id;
-                // Check if there are user messages after this video
-                const videoIdx = idx;
-                const hasMessageAfter = timeline.slice(videoIdx + 1).some(i => i.kind === 'user');
-                // Expand if it's the latest video and no messages after it
-                const shouldExpand = isLatestVideo && !hasMessageAfter;
-                // Show accept/regenerate only on latest video in preview phase
-                const isActivePreview = isLatestVideo && state.phase === 'preview' && !hasMessageAfter;
+      {/* ── Scrollable content area ──────────────────────────────────── */}
+      <div
+        ref={chatScrollRef}
+        className="nowheel nopan nodrag cursor-text select-text flex-1 overflow-y-auto overflow-x-hidden min-h-0 scrollbar-hidden bg-[linear-gradient(180deg,var(--an-bg)_0%,var(--an-bg-card)_100%)]"
+        style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' } as React.CSSProperties}
+        onWheel={(e) => { if (!e.ctrlKey) e.stopPropagation(); }}
+      >
+        <div className="px-4 py-3 space-y-3">
+          {/* ── Progress section ─────────────────────────────────────── */}
+          {state.execution?.todos && state.execution.todos.length > 0 && (
+            <div className="rounded-xl border border-[var(--an-border-input)] bg-[var(--an-bg)]/90">
+              <TodoSection todos={state.execution.todos} />
+            </div>
+          )}
 
-                return (
-                  <VideoCard
-                    key={item.id}
-                    videoUrl={item.videoUrl}
-                    duration={item.duration}
-                    expanded={shouldExpand}
-                    isActivePreview={isActivePreview}
-                    onAccept={isActivePreview ? handleAcceptPreview : undefined}
-                    onRegenerate={isActivePreview ? handleRegenerate : undefined}
-                    semanticEditOptions={isActivePreview ? [...DEFAULT_SEMANTIC_MOTION_CHIPS] : undefined}
-                    onSemanticEdit={isActivePreview ? handleSendMessage : undefined}
-                  />
-                );
-              }
-              if (item.kind === 'thinking') {
-                return (
-                  <ThinkingBlock
-                    key={item.id}
-                    thinking={item.label}
-                    reasoning={item.reasoning}
-                    isStreaming={!!item.isActive}
-                    startedAt={item.ts}
-                    endedAt={item.isActive ? undefined : (item.duration !== undefined ? new Date(new Date(item.ts).getTime() + item.duration * 1000).toISOString() : undefined)}
-                  />
-                );
-              }
-              return null;
-            })}
-
-            {/* Thinking shimmer — visible whenever streaming with no visible text output */}
-            {(
-              (isStreaming && !state.execution?.streamingText) ||
-              (state.phase === 'executing' && state.execution?.thinking && !isStreaming && !state.execution?.streamingText && state.execution?.todos.length === 0)
-            ) && (
-              <div className="py-2">
-                <span
-                  className="text-[11px] font-medium text-[var(--an-text-muted)]"
-                  style={{ animation: 'think-shimmer 2.5s ease-in-out infinite' }}
-                >
-                  {state.execution?.thinking || 'Working on it...'}
-                </span>
+          {/* ── Media strip ──────────────────────────────────────────── */}
+          {media.length > 0 && (
+            <div className="rounded-xl border border-[var(--an-border-input)] bg-[var(--an-bg)]/90 px-3 py-2.5">
+              <div className="mb-1.5 flex items-center justify-between text-[10px] text-[var(--an-text-dim)]">
+                <span>Attached media</span>
+                <span>{media.length} item{media.length === 1 ? '' : 's'}</span>
               </div>
-            )}
-
-            {/* Guided motion intake (#93/#94) */}
-            {state.phase === 'question' && guidedPrompt && (
-              <div className="rounded-lg bg-[var(--an-bg-elevated)] border border-[var(--an-border-input)] p-2.5 space-y-2">
-                <p className="text-[11px] font-medium text-[var(--an-text-muted)]">
-                  Pick a motion direction
-                </p>
-                <p className="text-[10px] text-[var(--an-text-placeholder)]">
-                  Your prompt is broad, so select intent chips and one variant (A/B/C).
-                </p>
-
-                {GUIDED_MOTION_GROUPS.map((group) => (
-                  <div key={group.key} className="space-y-1">
-                    <p className="text-[10px] text-[var(--an-text-dim)]">{group.label}</p>
-                    <div className="flex flex-wrap gap-1">
-                      {group.options.map((option) => {
-                        const selected = guidedChips[group.key] === option.id;
-                        return (
-                          <button
-                            key={`${group.key}-${String(option.id)}`}
-                            onClick={() => setGuidedChips((prev) => ({ ...prev, [group.key]: option.id } as MotionIntentChips))}
-                            className={`px-2 py-1 rounded-md border text-[10px] transition-colors ${
-                              selected
-                                ? 'bg-[var(--an-accent-bg)] border-[var(--an-accent)] text-[var(--an-accent-text)]'
-                                : 'bg-[var(--an-bg-card)] border-[var(--an-border-input)] text-[var(--an-text-dim)] hover:border-[var(--an-border-hover)]'
-                            }`}
-                          >
-                            {option.label}
-                          </button>
-                        );
-                      })}
+              <div className="flex gap-1.5 overflow-x-auto scrollbar-hidden items-center">
+                {media.map((m) => (
+                  <div key={m.id} className="relative group flex-shrink-0">
+                    <div className="w-10 h-10 rounded-md bg-[var(--an-bg-card)] overflow-hidden border border-[var(--an-border-input)]">
+                      {m.type === 'image' ? (
+                        <img src={m.dataUrl} alt={m.name} className="w-full h-full object-cover" />
+                      ) : (
+                        <div className="w-full h-full flex items-center justify-center">
+                          <Video className="w-3 h-3 text-purple-400" />
+                        </div>
+                      )}
                     </div>
+                    {m.source === 'upload' && (
+                      <button
+                        onClick={() => handleRemoveMedia(m.id)}
+                        className="absolute -top-1 -right-1 w-3.5 h-3.5 rounded-full bg-red-500/90 flex items-center justify-center opacity-90 hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/80 transition-opacity"
+                        title={`Remove ${m.name}`}
+                        aria-label={`Remove ${m.name}`}
+                      >
+                        <X className="w-2 h-2 text-white" />
+                      </button>
+                    )}
+                    {(m.source === 'edge' || (m.type === 'video' && m.duration)) && (
+                      <span className="absolute bottom-0 left-0 right-0 text-[6px] text-center text-zinc-400 bg-black/60 truncate px-0.5">
+                        {m.type === 'video' && m.duration ? `${m.duration.toFixed(1)}s` : ''}
+                        {m.source === 'edge' ? '⚡' : ''}
+                      </span>
+                    )}
                   </div>
                 ))}
+              </div>
+            </div>
+          )}
 
-                <div className="space-y-1">
-                  <p className="text-[10px] text-[var(--an-text-dim)]">Motion variants</p>
-                  <div className="grid grid-cols-3 gap-1.5">
-                    {guidedVariantOptions.map((variant) => {
-                      const selected = guidedVariant === variant.id;
+          {/* ── Timeline items ──────────────────────────────────────── */}
+          {hasTimelineContent ? (
+            <>
+              {/* Timeline items - messages, plan, and videos in chronological order */}
+              {timeline.map((item, idx) => {
+                if (item.kind === 'user') {
+                  return <UserBubble key={item.id} content={item.content} media={item.media} />;
+                }
+                if (item.kind === 'assistant') {
+                  return <AssistantText key={item.id} content={item.content} />;
+                }
+                if (item.kind === 'plan' && state.plan) {
+                  return (
+                    <PlanCard
+                      key={item.id}
+                      plan={state.plan}
+                      accepted={!!state.planAccepted}
+                      onAccept={handleAcceptPlan}
+                      onReject={handleRejectPlan}
+                    />
+                  );
+                }
+                if (item.kind === 'video') {
+                  // Check if this is the latest video (last video in the timeline)
+                  const isLatestVideo = timeline.filter(i => i.kind === 'video').pop()?.id === item.id;
+                  // Check if there are user messages after this video
+                  const videoIdx = idx;
+                  const hasMessageAfter = timeline.slice(videoIdx + 1).some(i => i.kind === 'user');
+                  // Expand if it's the latest video and no messages after it
+                  const shouldExpand = isLatestVideo && !hasMessageAfter;
+                  // Show accept/regenerate only on latest video in preview phase
+                  const isActivePreview = isLatestVideo && state.phase === 'preview' && !hasMessageAfter;
+
+                  return (
+                    <VideoCard
+                      key={item.id}
+                      videoUrl={item.videoUrl}
+                      duration={item.duration}
+                      expanded={shouldExpand}
+                      isActivePreview={isActivePreview}
+                      onAccept={isActivePreview ? handleAcceptPreview : undefined}
+                      onRegenerate={isActivePreview ? handleRegenerate : undefined}
+                      semanticEditOptions={isActivePreview ? [...DEFAULT_SEMANTIC_MOTION_CHIPS] : undefined}
+                      onSemanticEdit={isActivePreview ? handleSendMessage : undefined}
+                    />
+                  );
+                }
+                if (item.kind === 'thinking') {
+                  return (
+                    <ThinkingBlock
+                      key={item.id}
+                      thinking={item.label}
+                      reasoning={item.reasoning}
+                      isStreaming={!!item.isActive}
+                      startedAt={item.ts}
+                      endedAt={item.isActive ? undefined : (item.duration !== undefined ? new Date(new Date(item.ts).getTime() + item.duration * 1000).toISOString() : undefined)}
+                    />
+                  );
+                }
+                return null;
+              })}
+            </>
+          ) : (
+            <div className="flex min-h-[180px] items-center justify-center rounded-xl border border-dashed border-[var(--an-border-input)] bg-[var(--an-bg)]/70 px-6 text-center">
+              <div className="space-y-1.5">
+                <p className="text-[12px] font-medium text-[var(--an-text-muted)]">
+                  Start the conversation
+                </p>
+                <p className="text-[11px] text-[var(--an-text-dim)]">
+                  Describe the animation you want and the chat will stay pinned while the history scrolls above it.
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* Thinking shimmer — visible whenever streaming with no visible text output */}
+          {(
+            (isStreaming && !state.execution?.streamingText) ||
+            (state.phase === 'executing' && state.execution?.thinking && !isStreaming && !state.execution?.streamingText && state.execution?.todos.length === 0)
+          ) && (
+            <div className="py-2">
+              <span
+                className="text-[11px] font-medium text-[var(--an-text-muted)]"
+                style={{ animation: 'think-shimmer 2.5s ease-in-out infinite' }}
+              >
+                {state.execution?.thinking || 'Working on it...'}
+              </span>
+            </div>
+          )}
+
+          {/* Guided motion intake (#93/#94) */}
+          {state.phase === 'question' && guidedPrompt && (
+            <div className="rounded-lg bg-[var(--an-bg-elevated)] border border-[var(--an-border-input)] p-2.5 space-y-2">
+              <p className="text-[11px] font-medium text-[var(--an-text-muted)]">
+                Pick a motion direction
+              </p>
+              <p className="text-[10px] text-[var(--an-text-placeholder)]">
+                Your prompt is broad, so select intent chips and one variant (A/B/C).
+              </p>
+
+              {GUIDED_MOTION_GROUPS.map((group) => (
+                <div key={group.key} className="space-y-1">
+                  <p className="text-[10px] text-[var(--an-text-dim)]">{group.label}</p>
+                  <div className="flex flex-wrap gap-1">
+                    {group.options.map((option) => {
+                      const selected = guidedChips[group.key] === option.id;
                       return (
                         <button
-                          key={variant.id}
-                          onClick={() => setGuidedVariant(variant.id)}
-                          className={`rounded-md border px-2 py-1 text-left transition-colors ${
+                          key={`${group.key}-${String(option.id)}`}
+                          onClick={() => setGuidedChips((prev) => ({ ...prev, [group.key]: option.id } as MotionIntentChips))}
+                          className={`px-2 py-1 rounded-md border text-[10px] transition-colors ${
                             selected
-                              ? 'bg-[var(--an-accent-bg)] border-[var(--an-accent)]'
-                              : 'bg-[var(--an-bg-card)] border-[var(--an-border-input)]'
+                              ? 'bg-[var(--an-accent-bg)] border-[var(--an-accent)] text-[var(--an-accent-text)]'
+                              : 'bg-[var(--an-bg-card)] border-[var(--an-border-input)] text-[var(--an-text-dim)] hover:border-[var(--an-border-hover)]'
                           }`}
                         >
-                          <p className="text-[10px] font-medium text-[var(--an-text-muted)]">{variant.label}</p>
-                          <p className="text-[9px] text-[var(--an-text-placeholder)]">{variant.description}</p>
+                          {option.label}
                         </button>
                       );
                     })}
                   </div>
                 </div>
+              ))}
 
-                <div className="space-y-1">
-                  <p className="text-[10px] text-[var(--an-text-dim)]">Optional follow-up</p>
-                  <textarea
-                    value={guidedFollowUp}
-                    onChange={(e) => setGuidedFollowUp(e.target.value)}
-                    rows={2}
-                    placeholder="Example: slower intro, cleaner transitions, stronger camera push in scene 2"
-                    className="w-full rounded-md border border-[var(--an-border-input)] bg-[var(--an-bg-card)] px-2 py-1.5 text-[10px] text-[var(--an-text)] outline-none focus:border-[var(--an-border-hover)] resize-none"
-                  />
-                </div>
-
-                <div className="flex items-center gap-2">
-                  <button
-                    onClick={() => handleApplyGuidedMotion()}
-                    className="flex-1 px-2.5 py-1.5 rounded-md bg-[var(--an-accent)] hover:bg-[var(--an-accent-hover)] text-white text-[11px] font-medium transition-colors"
-                  >
-                    Apply & Continue
-                  </button>
-                  <button
-                    onClick={handleSkipGuidedMotion}
-                    className="px-2.5 py-1.5 rounded-md border border-[var(--an-border-input)] bg-[var(--an-bg-card)] text-[10px] text-[var(--an-text-dim)] hover:border-[var(--an-border-hover)]"
-                  >
-                    Skip
-                  </button>
+              <div className="space-y-1">
+                <p className="text-[10px] text-[var(--an-text-dim)]">Motion variants</p>
+                <div className="grid grid-cols-3 gap-1.5">
+                  {guidedVariantOptions.map((variant) => {
+                    const selected = guidedVariant === variant.id;
+                    return (
+                      <button
+                        key={variant.id}
+                        onClick={() => setGuidedVariant(variant.id)}
+                        className={`rounded-md border px-2 py-1 text-left transition-colors ${
+                          selected
+                            ? 'bg-[var(--an-accent-bg)] border-[var(--an-accent)]'
+                            : 'bg-[var(--an-bg-card)] border-[var(--an-border-input)]'
+                        }`}
+                      >
+                        <p className="text-[10px] font-medium text-[var(--an-text-muted)]">{variant.label}</p>
+                        <p className="text-[9px] text-[var(--an-text-placeholder)]">{variant.description}</p>
+                      </button>
+                    );
+                  })}
                 </div>
               </div>
-            )}
 
-            {/* Multi-question form */}
-            {state.phase === 'question' && state.formQuestion && (
-              <QuestionForm
-                content={state.formQuestion.content}
-                fields={state.formQuestion.fields}
-                onSubmit={handleFormSubmit}
-              />
-            )}
-
-            {/* Single question options (backward compat) */}
-            {state.phase === 'question' && state.question && !state.formQuestion && (
-              <>
-                <AssistantText content={state.question.text} />
-                <QuestionOptions question={state.question} onSelect={handleSelectStyle} />
-              </>
-            )}
-
-            {/* Complete output */}
-            {state.phase === 'complete' && state.output && (
-              <div className="rounded-lg overflow-hidden bg-[var(--an-bg-elevated)] border border-[var(--an-border-input)]">
-                <video
-                  src={state.output.videoUrl}
-                  controls
-                  className="w-full"
-                  style={{ maxHeight: '180px' }}
+              <div className="space-y-1">
+                <p className="text-[10px] text-[var(--an-text-dim)]">Optional follow-up</p>
+                <textarea
+                  value={guidedFollowUp}
+                  onChange={(e) => setGuidedFollowUp(e.target.value)}
+                  rows={2}
+                  placeholder="Example: slower intro, cleaner transitions, stronger camera push in scene 2"
+                  className="w-full rounded-md border border-[var(--an-border-input)] bg-[var(--an-bg-card)] px-2 py-1.5 text-[10px] text-[var(--an-text)] outline-none focus:border-[var(--an-border-hover)] resize-none"
                 />
-                <div className="flex items-center justify-between p-2">
-                  <span className="text-[10px] text-[#22C55E] font-medium">Animation complete</span>
-                  <button
-                    onClick={handleReset}
-                    className="px-2.5 py-1 rounded-md bg-[var(--an-bg-card)] text-[var(--an-text-muted)] text-[10px] font-medium hover:bg-[var(--an-bg-hover)] transition-colors"
-                  >
-                    New Animation
-                  </button>
-                </div>
               </div>
-            )}
 
-            {/* Error display */}
-            {state.phase === 'error' && state.error && (
-              <div className="space-y-2">
-                <div className="px-2.5 py-2 rounded-md bg-[var(--an-bg-error)] border border-[var(--an-border-error)]">
-                  <p className="text-[11px] text-[#FCA5A5] font-medium">{state.error.message}</p>
-                  {state.error.details && (
-                    <p className="text-[10px] text-[var(--an-text-dim)] mt-1">{state.error.details}</p>
-                  )}
-                </div>
-                {state.error.canRetry && <RetryButton onRetry={handleRetry} />}
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => handleApplyGuidedMotion()}
+                  className="flex-1 px-2.5 py-1.5 rounded-md bg-[var(--an-accent)] hover:bg-[var(--an-accent-hover)] text-white text-[11px] font-medium transition-colors"
+                >
+                  Apply & Continue
+                </button>
+                <button
+                  onClick={handleSkipGuidedMotion}
+                  className="px-2.5 py-1.5 rounded-md border border-[var(--an-border-input)] bg-[var(--an-bg-card)] text-[10px] text-[var(--an-text-dim)] hover:border-[var(--an-border-hover)]"
+                >
+                  Skip
+                </button>
               </div>
-            )}
-          </div>
-        </div>
-      )}
+            </div>
+          )}
 
-      {/* ── Sticky todo section ──────────────────────────────────────── */}
-      {state.execution?.todos && state.execution.todos.length > 0 && (
-        <div className="flex-shrink-0 border-t border-[var(--an-border)] bg-[var(--an-bg-card)] px-1.5 py-1.5">
-          <TodoSection todos={state.execution.todos} />
-        </div>
-      )}
+          {/* Multi-question form */}
+          {state.phase === 'question' && state.formQuestion && (
+            <QuestionForm
+              content={state.formQuestion.content}
+              fields={state.formQuestion.fields}
+              onSubmit={handleFormSubmit}
+            />
+          )}
 
-      {/* ── Media strip (thumbnails of attached media) */}
-      {media.length > 0 && (
-        <div className="flex-shrink-0 border-t border-[var(--an-border)] bg-[var(--an-bg-card)] px-3.5 py-2">
-          <div className="mb-1.5 flex items-center justify-between text-[10px] text-[var(--an-text-dim)]">
-            <span>Attached media</span>
-            <span>{media.length} item{media.length === 1 ? '' : 's'}</span>
-          </div>
-          <div className="flex gap-1.5 overflow-x-auto scrollbar-hidden items-center">
-            {media.map((m) => (
-              <div key={m.id} className="relative group flex-shrink-0">
-                <div className="w-10 h-10 rounded-md bg-[var(--an-bg)] overflow-hidden border border-[var(--an-border-input)]">
-                  {m.type === 'image' ? (
-                    <img src={m.dataUrl} alt={m.name} className="w-full h-full object-cover" />
-                  ) : (
-                    <div className="w-full h-full flex items-center justify-center">
-                      <Video className="w-3 h-3 text-purple-400" />
-                    </div>
-                  )}
-                </div>
-                {m.source === 'upload' && (
-                  <button
-                    onClick={() => handleRemoveMedia(m.id)}
-                    className="absolute -top-1 -right-1 w-3.5 h-3.5 rounded-full bg-red-500/90 flex items-center justify-center opacity-90 hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/80 transition-opacity"
-                    title={`Remove ${m.name}`}
-                    aria-label={`Remove ${m.name}`}
-                  >
-                    <X className="w-2 h-2 text-white" />
-                  </button>
-                )}
-                {(m.source === 'edge' || (m.type === 'video' && m.duration)) && (
-                  <span className="absolute bottom-0 left-0 right-0 text-[6px] text-center text-zinc-400 bg-black/60 truncate px-0.5">
-                    {m.type === 'video' && m.duration ? `${m.duration.toFixed(1)}s` : ''}
-                    {m.source === 'edge' ? '⚡' : ''}
-                  </span>
+          {/* Single question options (backward compat) */}
+          {state.phase === 'question' && state.question && !state.formQuestion && (
+            <>
+              <AssistantText content={state.question.text} />
+              <QuestionOptions question={state.question} onSelect={handleSelectStyle} />
+            </>
+          )}
+
+          {/* Complete output */}
+          {state.phase === 'complete' && state.output && (
+            <div className="rounded-lg overflow-hidden bg-[var(--an-bg-elevated)] border border-[var(--an-border-input)]">
+              <video
+                src={state.output.videoUrl}
+                controls
+                className="w-full"
+                style={{ maxHeight: '180px' }}
+              />
+              <div className="flex items-center justify-between p-2">
+                <span className="text-[10px] text-[#22C55E] font-medium">Animation complete</span>
+                <button
+                  onClick={handleReset}
+                  className="px-2.5 py-1 rounded-md bg-[var(--an-bg-card)] text-[var(--an-text-muted)] text-[10px] font-medium hover:bg-[var(--an-bg-hover)] transition-colors"
+                >
+                  New Animation
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Error display */}
+          {state.phase === 'error' && state.error && (
+            <div className="space-y-2">
+              <div className="px-2.5 py-2 rounded-md bg-[var(--an-bg-error)] border border-[var(--an-border-error)]">
+                <p className="text-[11px] text-[#FCA5A5] font-medium">{state.error.message}</p>
+                {state.error.details && (
+                  <p className="text-[10px] text-[var(--an-text-dim)] mt-1">{state.error.details}</p>
                 )}
               </div>
-            ))}
-          </div>
+              {state.error.canRetry && <RetryButton onRetry={handleRetry} />}
+            </div>
+          )}
         </div>
-      )}
-
-      {/* Spacer: pushes chat input to bottom when no timeline content */}
-      {!hasTimelineContent && <div className="flex-1" />}
+      </div>
 
       {/* ── Chat input (always visible) ──────────────────────────────── */}
       <div className="shrink-0 border-t border-[var(--an-border)] bg-[linear-gradient(180deg,var(--an-bg-card)_0%,var(--an-bg)_100%)] nopan nodrag nowheel">


### PR DESCRIPTION
## Summary
- keep the animation chat composer pinned at the bottom of the node
- move chat history, progress, media, and completion UI into a single scrollable content area
- preserve the existing question and output states while preventing generated output from hiding the input

## Verification
- npx eslint src/lib/plugins/official/agents/animation-generator/AnimationNode.tsx src/lib/plugins/official/agents/animation-generator/components/ChatInput.tsx
