### PR TITLE
Force animation node card to keep flex layout

### DIFF
--- a/src/lib/plugins/official/agents/animation-generator/AnimationNode.tsx
+++ b/src/lib/plugins/official/agents/animation-generator/AnimationNode.tsx
@@ -2398,12 +2398,12 @@ function AnimationNodeComponent({ id, data, selected }: AnimationNodeProps) {
 
   // ─── Node styling ──────────────────────────────────────────────────
   const nodeClasses = useMemo(() => {
-    const base = 'node-drag-handle node-drag-surface animation-node w-[420px] rounded-2xl overflow-hidden flex flex-col shadow-[var(--node-card-shadow)]';
+    const base = 'node-drag-handle node-drag-surface animation-node w-[420px] rounded-2xl overflow-hidden !flex !flex-col shadow-[var(--node-card-shadow)]';
     if (selected) return `${base} ring-1 ring-[var(--an-accent)]/70`;
     return base;
   }, [selected]);
   const summaryContainerClass = useMemo(() => {
-    const base = 'node-drag-handle node-drag-surface animation-node w-[420px] rounded-2xl overflow-hidden flex flex-col shadow-[var(--node-card-shadow)]';
+    const base = 'node-drag-handle node-drag-surface animation-node w-[420px] rounded-2xl overflow-hidden !flex !flex-col shadow-[var(--node-card-shadow)]';
     return selected ? `${base} ring-1 ring-[var(--an-accent)]/70` : base;
   }, [selected]);
   const latestVersion = state.versions?.[state.versions.length - 1];


### PR DESCRIPTION
## Summary
- force the animation node root card to remain a flex column
- prevent shared drag-surface CSS from collapsing the layout to block
- keep the chat composer pinned to the bottom instead of being pushed out of the card

## Verification
- npx eslint src/lib/plugins/official/agents/animation-generator/AnimationNode.tsx
