### PR TITLE
Make animation chat composer fill the node width

### DIFF
--- a/src/lib/plugins/official/agents/animation-generator/AnimationNode.tsx
+++ b/src/lib/plugins/official/agents/animation-generator/AnimationNode.tsx
@@ -2398,12 +2398,12 @@ function AnimationNodeComponent({ id, data, selected }: AnimationNodeProps) {
 
   // ─── Node styling ──────────────────────────────────────────────────
   const nodeClasses = useMemo(() => {
-    const base = 'node-drag-handle node-drag-surface animation-node w-[420px] rounded-2xl overflow-hidden !flex !flex-col shadow-[var(--node-card-shadow)]';
+    const base = 'node-drag-handle node-drag-surface animation-node w-[420px] rounded-2xl overflow-hidden !flex !flex-col !items-stretch shadow-[var(--node-card-shadow)]';
     if (selected) return `${base} ring-1 ring-[var(--an-accent)]/70`;
     return base;
   }, [selected]);
   const summaryContainerClass = useMemo(() => {
-    const base = 'node-drag-handle node-drag-surface animation-node w-[420px] rounded-2xl overflow-hidden !flex !flex-col shadow-[var(--node-card-shadow)]';
+    const base = 'node-drag-handle node-drag-surface animation-node w-[420px] rounded-2xl overflow-hidden !flex !flex-col !items-stretch shadow-[var(--node-card-shadow)]';
     return selected ? `${base} ring-1 ring-[var(--an-accent)]/70` : base;
   }, [selected]);
   const latestVersion = state.versions?.[state.versions.length - 1];

--- a/src/lib/plugins/official/agents/animation-generator/AnimationNode.tsx
+++ b/src/lib/plugins/official/agents/animation-generator/AnimationNode.tsx
@@ -2582,7 +2582,7 @@ function AnimationNodeComponent({ id, data, selected }: AnimationNodeProps) {
       }}
     >
       {/* ── Header ───────────────────────────────────────────────────── */}
-      <div className="flex-shrink-0 border-b border-[var(--an-border)] bg-[var(--an-bg-card)] px-4 py-3">
+      <div className="w-full flex-shrink-0 border-b border-[var(--an-border)] bg-[var(--an-bg-card)] px-4 py-3">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
             <p className="text-[10px] uppercase tracking-[0.14em] text-[var(--an-text-dim)]">
@@ -2609,7 +2609,7 @@ function AnimationNodeComponent({ id, data, selected }: AnimationNodeProps) {
       {/* ── Scrollable content area ──────────────────────────────────── */}
       <div
         ref={chatScrollRef}
-        className="nowheel nopan nodrag cursor-text select-text flex-1 overflow-y-auto overflow-x-hidden min-h-0 scrollbar-hidden bg-[linear-gradient(180deg,var(--an-bg)_0%,var(--an-bg-card)_100%)]"
+        className="nowheel nopan nodrag cursor-text select-text w-full flex-1 overflow-y-auto overflow-x-hidden min-h-0 scrollbar-hidden bg-[linear-gradient(180deg,var(--an-bg)_0%,var(--an-bg-card)_100%)]"
         style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' } as React.CSSProperties}
         onWheel={(e) => { if (!e.ctrlKey) e.stopPropagation(); }}
       >
@@ -2891,7 +2891,7 @@ function AnimationNodeComponent({ id, data, selected }: AnimationNodeProps) {
       </div>
 
       {/* ── Chat input (always visible) ──────────────────────────────── */}
-      <div className="shrink-0 border-t border-[var(--an-border)] bg-[linear-gradient(180deg,var(--an-bg-card)_0%,var(--an-bg)_100%)] nopan nodrag nowheel">
+      <div className="w-full shrink-0 border-t border-[var(--an-border)] bg-[linear-gradient(180deg,var(--an-bg-card)_0%,var(--an-bg)_100%)] nopan nodrag nowheel">
         <ChatInput
           onSubmit={handleInputSubmit}
           isGenerating={isStreaming}

--- a/src/lib/plugins/official/agents/animation-generator/components/ChatInput.tsx
+++ b/src/lib/plugins/official/agents/animation-generator/components/ChatInput.tsx
@@ -203,7 +203,7 @@ export function ChatInput({
   const canSend = !disabled && message.trim().length > 0;
 
   return (
-    <div className="px-3.5 pt-3 pb-3.5">
+    <div className="w-full px-3.5 pt-3 pb-3.5">
       {/* Queued messages section */}
       {queue.length > 0 && (
         <div className="mb-2.5 rounded-xl bg-[var(--an-bg-elevated)] border border-[var(--an-border-input)] overflow-hidden shadow-[0_10px_24px_-20px_rgba(15,23,42,0.5)]">
@@ -286,7 +286,7 @@ export function ChatInput({
 
       {/* Input box */}
       <div
-        className="rounded-[16px] border border-[var(--an-border-input)] overflow-hidden shadow-[0_18px_44px_-28px_rgba(15,23,42,0.45)]"
+        className="w-full rounded-[16px] border border-[var(--an-border-input)] overflow-hidden shadow-[0_18px_44px_-28px_rgba(15,23,42,0.45)]"
         style={{ backgroundColor: 'var(--an-bg-input)' }}
       >
         {/* Textarea area */}


### PR DESCRIPTION
## Summary
- stretch the animation node root layout instead of centering child sections
- make the header, scroll area, and footer span the full node width
- make the chat composer wrapper explicitly full width so it stays flush with the card

## Verification
- npx eslint src/lib/plugins/official/agents/animation-generator/AnimationNode.tsx src/lib/plugins/official/agents/animation-generator/components/ChatInput.tsx
